### PR TITLE
Add notes on metadata-only upload config

### DIFF
--- a/admin-manual/installation/dashboard-config.rst
+++ b/admin-manual/installation/dashboard-config.rst
@@ -287,6 +287,13 @@ be enabled in order for AtoM to receive uploaded DIPs. Enabling Job scheduling
 documentation, see :ref:`Settings <atom:settings>` and
 :ref:`Plugins <atom:manage-plugins>`.
 
+.. NOTE::
+
+   If you are planning to use the *metadata-only DIP upload to AtoM*
+   functionality don't forget to enable the :ref:`the API plugin in AtoM
+   <atom:api-intro>`, generate a API key and update the ``REST API key`` field
+   accordingly. Metadata-only upload is only available since AtoM 2.4.
+
 AtoM server configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Feel free to change/correct my grammar, but consider this a reminder that we need to specify in the docs how to set up things on AtoM so the metadata-only DIP upload is possible!
