### PR TITLE
Update CentOS/RHEL New Install section AM1.6

### DIFF
--- a/admin-manual/installation/installation.rst
+++ b/admin-manual/installation/installation.rst
@@ -307,6 +307,12 @@ Archivematica version 1.5.1 and higher support installation on CentOS/Redhat.
 
 **Prerequisites**
 
+Update your system
+
+.. code:: bash
+
+   sudo yum update
+
 Extra repos:
 
 Some repositories need to be installed in order to fullfill the installation procedure:
@@ -338,7 +344,7 @@ Some repositories need to be installed in order to fullfill the installation pro
    sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica.repo
    [archivematica]
    name=archivematica
-   baseurl=https://packages.archivematica.org/1.5.x/centos
+   baseurl=https://packages.archivematica.org/1.6.x/centos
    gpgcheck=0
    enabled=1
    EOF'
@@ -447,7 +453,7 @@ Common services like elasticsearch, mariadb and gearmand should be installed and
    sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica-extras.repo
    [archivematica-extras]
    name=archivematica-extras
-   baseurl=https://packages.archivematica.org/1.5.x/centos-extras
+   baseurl=https://packages.archivematica.org/1.6.x/centos-extras
    gpgcheck=0
    enabled=1
    EOF'
@@ -501,6 +507,7 @@ Each service have a configuration file in /etc/sysconfig/archivematica-packagena
 
 If IPv6 is disabled, Nginx may refuse to start. If that is the case make sure that the listen directives used under /etc/nginx are not using IPv6 addresses like [::]:80.
 
+CentOS will install firewalld which will be running default rules likely blocking ports 81 and 8001. If you are not able to access the dashboard and storage service, check if firewalld is running. If it is, you will likely need to modify the firewall rules to allow access to ports 81 and 8001 from your location.
 
 .. _centos-upgrade:
 


### PR DESCRIPTION
This commit modifies the CentOS/RHEL new install section:
- Update the packages url to pull from the 1.6.x folder for the archivematica
and archivematica-extras repos.
- Add a troubleshooting note for users to look at their firewall settings if
they are unable to access port 81 and 8001.