### PR TITLE
add link to import metadata in premis.rst

### DIFF
--- a/user-manual/metadata/premis.rst
+++ b/user-manual/metadata/premis.rst
@@ -7,6 +7,8 @@ PREMIS metadata in Archivematica
 Archivematica supports the entry of `PREMIS <http://www.loc.gov/standards/premis/>`_
 rights metadata during :ref:`transfer <transfer>` or :ref:`ingest <ingest>`.
 Rights entered via the GUI interface apply to the entirety of the SIP or transfer.
+Rights can also be entered at the object level by describing them in a rights.csv
+file and using the :ref: `Import Metadata <_import-metadata>` feature.
 
 Below, the entry template is described as it appears for each rights basis,
 followed by acts granted/restricted.


### PR DESCRIPTION
Added comment with reference to the Import Metadata documentation which describes how to import PREMIS metadata using a right.csv file.