### PR TITLE
Add README to archivematica-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Archivematica documentation
+
+[Archivematica](https://www.archivematica.org/en/) is a web- and standards-based, open-source application which allows your institution to preserve long-term access to trustworthy, authentic and reliable digital content.
+Our target users are archivists, librarians, and anyone working to preserve digital objects.
+
+You are free to copy, modify, and distribute the Archivematica documentation with attribution under the terms of the Creative Commons Attribution Share Alike 4.0 (CC-BY-SA-4.0) license.
+See the [LICENCE](LICENCE) file for details.
+
+# Contributing
+
+Thank you for considering a contribution to the Archivematica documentation!
+For more information on contributing, please see the [Archivematica docs Github wiki](https://github.com/artefactual/archivematica-docs/wiki).
+The wiki describes the change submission process for the Archivematica docs and includes a style guide for new contributions.
+Following these guidelines helps us assess your changes faster and makes it easier for us to merge your submission.
+
+Note that some documentation lives in separate repositories:
+
+* [Archivematica docs](https://github.com/artefactual/archivematica-docs): This repository! Contains the main user and administrator docs.
+* [Storage Service docs](https://github.com/artefactual/archivematica-storage-service-docs): Contains documentation for the Storage Service, Archivematica's back end.
+* [Format Policy Registry docs](https://github.com/artefactual/archivematica-fpr-admin/tree/dev/docs): Contains documentation for the Format Policy Registry, which feeds Archivematica preservation planning rules and commands.


### PR DESCRIPTION
I've added a very basic README that has boilerplate information on the project, the license for the documentation, and instructions on where to go if users want to contribute to the docs. Any suggestions or additions are welcome!