### PR TITLE
sips are created from archival objects but not resources

### DIFF
--- a/user-manual/appraisal/appraisal.rst
+++ b/user-manual/appraisal/appraisal.rst
@@ -216,7 +216,9 @@ by the parallel lines icon.
 
 .. note::
 
-   Digital objects created and linked to resources in ArchivesSpace will not appear in the ArchivesSpace panel. However, digital objects added to a resource from within the ArchivesSpace panel are displayed.
+   Digital objects created and linked to resources in ArchivesSpace will 
+   not appear in the ArchivesSpace panel. However, digital objects added 
+   to a resource from within the ArchivesSpace panel are displayed.
 
 .. image:: images/archivesspace_search.*
    :align: center
@@ -230,7 +232,8 @@ Options at the top of the ArchivesSpace pane allow for adding to and changing an
 existing ArchivesSpace resource, such as adding new archival objects and digital
 object components.
 
-Selecting a resource or archival object and using “Add new child record” adds a new archival object nested underneath the selected level of description.
+Selecting a resource or archival object and using “Add new child record” adds 
+a new archival object nested underneath the selected level of description.
 Clicking this button brings up a dialog box for entering metadata. At a minimum,
 a new archival object must have a title and a level of description, otherwise
 “save” is not available.

--- a/user-manual/appraisal/appraisal.rst
+++ b/user-manual/appraisal/appraisal.rst
@@ -334,9 +334,7 @@ To add files to ArchivesSpace resources:
 
 5. Once all files have been added and the arrangement has been set, SIPs can be
    started in Ingest. Select the resource/archival object and click
-   **Finalize arrangement**. SIPs can be created from any level of description
-   (i.e. a SIP can be started for an entire resource or from an archival object
-   within a resource such as a series).
+   **Finalize arrangement**. SIPs can be created from ArchivesSpace archival objects at any level of description.
 
 .. tip::
 


### PR DESCRIPTION
This is (I think) a slightly less ambiguous way to describe what SIPs can be created from, based on the conversation on the [Appraisal tab Backlog pane / ArchivesSpace pane question](https://groups.google.com/forum/#!topic/archivematica/815b8wk7jR4) thread.