### PR TITLE
Use CentOS/Ubuntu dev repos during dev stage

### DIFF
--- a/admin-manual/installation-setup/installation/install-centos.rst
+++ b/admin-manual/installation-setup/installation/install-centos.rst
@@ -68,6 +68,36 @@ Installation instructions
 
    * Archivematica:
 
+   While Archivematica 1.7 is in development, please use these commands to
+   install the development repositories:
+
+   .. code:: bash
+
+      sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica.repo
+      [archivematica]
+      name=archivematica
+      baseurl=http://jenkins-ci.archivematica.org/repos/rpm/release-1.7/
+      gpgcheck=0
+      enabled=1
+      [archivematica-storage-service]
+      name=archivematica-storage-service
+      baseurl=http://jenkins-ci.archivematica.org/repos/rpm/release-0.11/
+      gpgcheck=0
+      enabled=1
+      EOF'
+
+      sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica-extras.repo
+      [archivematica-extras]
+      name=archivematica-extras
+      baseurl=https://packages.archivematica.org/1.7.x/centos-extras
+      gpgcheck=1
+      gpgkey=https://packages.archivematica.org/1.7.x/devel.key
+      enabled=1
+      EOF'
+
+   If the release has been completed, you should use these commands to install
+   the final repositories:
+
    .. code:: bash
 
       sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica.repo

--- a/admin-manual/installation-setup/installation/install-ubuntu.rst
+++ b/admin-manual/installation-setup/installation/install-ubuntu.rst
@@ -23,10 +23,8 @@ place to store packages for multiple operating systems. Packages for both Ubuntu
 Ubuntu 16.04 (Xenial) installation instructions
 ===============================================
 
-1. Add packages.archivematica.org to your list of trusted repositories.
-
-   Run these three commands right now (**and delete this section when the final
-   release packages are made**):
+1. While Archivematica 1.7 is in development, please use these commands to
+   install the development repositories:
 
    .. code:: bash
 
@@ -36,7 +34,8 @@ Ubuntu 16.04 (Xenial) installation instructions
       sudo sh -c 'echo "deb http://jenkins-ci.archivematica.org/repos/apt/release-1.7-xenial/ ./" >> /etc/apt/sources.list'
       sudo sh -c 'echo "deb [arch=amd64] http://packages.archivematica.org/1.7.x/ubuntu-externals xenial main" >> /etc/apt/sources.list'
 
-   Run these three commands when the final release packages are made:
+   If the release has been completed, you should use these commands to install
+   the final repositories:
 
    .. code:: bash
 


### PR DESCRIPTION
We were already asking users to install the temporary repos in Ubuntu environments. This just extends the same solution to CentOS environments.

This closes https://github.com/artefactual/archivematica-docs/issues/121 and https://github.com/artefactual/archivematica-docs/issues/120.