### PR TITLE
Issue: IP requirements are unclear

### DIFF
--- a/admin-manual/installation-setup/installation/install-ansible.rst
+++ b/admin-manual/installation-setup/installation/install-ansible.rst
@@ -107,9 +107,9 @@ the configuration of your new server.
    ``http://<MY-IP-ADDR>:8000`` (or ``http://localhost:8000`` or
    ``http://127.0.0.1:8000`` if this is a local development setup).
 
-   If you are using a public IP address, you will need to configure your
-   firewall rules and allow access only to ports 80 and 8000 for Archivematica
-   usage.
+   If you are using an IP address or fully-qualified domain name instead of
+   localhost, you will need to configure your firewall rules and allow access
+   only to ports 80 and 8000 for Archivematica usage.
 
 2. The Storage Service has its own set of users. Navigate to
    **Administration > Users** and add at least one administrative user. After
@@ -141,11 +141,12 @@ the configuration of your new server.
      the same machine, then you should supply ``http://127.0.0.1:8000`` as the
      Storage Service URL at this screen.
    - If the Storage Service and the Archivematica dashboard are installed on
-     different nodes (servers), then you must use the public IP of your Storage
-     Service instance, e.g., ``http://<MY-IP-ADDR>:8000`` *and* you must ensure
-     that any firewall rules (i.e., iptables, ufw, AWS security groups, etc.)
-     are configured to allow requests from your dashboard IP to your Storage
-     Service IP on the appropriate port.
+     different nodes (servers), then you should use the IP address or
+     fully-qualified domain name of your Storage Service instance,
+     e.g., ``http://<MY-IP-ADDR>:8000`` *and* you must ensure that any firewall
+     rules (i.e., iptables, ufw, AWS security groups, etc.) are configured to
+     allow requests from your dashboard IP to your Storage Service IP on the
+     appropriate port.
 
 :ref:`Back to the top <install-ansible>`
 

--- a/admin-manual/installation-setup/installation/install-centos.rst
+++ b/admin-manual/installation-setup/installation/install-centos.rst
@@ -337,9 +337,9 @@ the configuration of your new server.
    ``http://127.0.0.1:8001`` if this is a local development setup). The default
    username and password are ``test``/ ``test``.
 
-   If you are using a public IP address, you will need to configure your
-   firewall rules and allow access only to ports 81 and 8001 for Archivematica
-   usage.
+   If you are using an IP address or fully-qualified domain name instead of
+   localhost, you will need to configure your firewall rules and allow access
+   only to ports 81 and 8001 for Archivematica usage.
 
 2. The Storage Service has its own set of users. Navigate to
    **Administration > Users** and add at least one administrative user. After
@@ -371,11 +371,12 @@ the configuration of your new server.
      the same machine, then you should supply ``http://127.0.0.1:8001`` as the
      Storage Service URL at this screen.
    - If the Storage Service and the Archivematica dashboard are installed on
-     different nodes (servers), then you must use the public IP of your Storage
-     Service instance, e.g., ``http://<MY-IP-ADDR>:8001`` *and* you must ensure
-     that any firewall rules (i.e., firewalld, AWS security groups, etc.) are
-     configured to allow requests from your dashboard IP to your Storage
-     Service IP on the appropriate port.
+     different nodes (servers), then you should use the IP address or
+     fully-qualified domain name of your Storage Service instance,
+     e.g., ``http://<MY-IP-ADDR>:8001`` *and* you must ensure that any firewall
+     rules (i.e., iptables, ufw, AWS security groups, etc.) are configured to
+     allow requests from your dashboard IP to your Storage Service IP on the
+     appropriate port.
 
 :ref:`Back to the top <install-pkg-centos>`
 

--- a/admin-manual/installation-setup/installation/install-ubuntu.rst
+++ b/admin-manual/installation-setup/installation/install-ubuntu.rst
@@ -388,9 +388,9 @@ the configuration of your new server.
    ``http://127.0.0.1:8000`` if this is a local development setup). The default
    username and password are ``test``/ ``test``.
 
-   If you are using a public IP address, you will need to configure your
-   firewall rules and allow access only to ports 80 and 8000 for Archivematica
-   usage.
+   If you are using an IP address or fully-qualified domain name instead of
+   localhost, you will need to configure your firewall rules and allow access
+   only to ports 81 and 8001 for Archivematica usage.
 
 2. The Storage Service has its own set of users. Navigate to
    **Administration > Users** and add at least one administrative user. After
@@ -422,11 +422,12 @@ the configuration of your new server.
      the same machine, then you should supply ``http://127.0.0.1:8000`` as the
      Storage Service URL at this screen.
    - If the Storage Service and the Archivematica dashboard are installed on
-     different nodes (servers), then you must use the public IP of your Storage
-     Service instance, e.g., ``http://<MY-IP-ADDR>:8000`` *and* you must ensure
-     that any firewall rules (i.e., iptables, ufw, AWS security groups, etc.)
-     are configured to allow requests from your dashboard IP to your Storage
-     Service IP on the appropriate port.
+     different nodes (servers), then you should use the IP address or
+     fully-qualified domain name of your Storage Service instance,
+     e.g., ``http://<MY-IP-ADDR>:8000`` *and* you must ensure that any firewall
+     rules (i.e., iptables, ufw, AWS security groups, etc.) are configured to
+     allow requests from your dashboard IP to your Storage Service IP on the
+     appropriate port.
 
 :ref:`Back to the top <install-pkg-ubuntu>`
 

--- a/admin-manual/installation-setup/installation/install-ubuntu.rst
+++ b/admin-manual/installation-setup/installation/install-ubuntu.rst
@@ -390,7 +390,7 @@ the configuration of your new server.
 
    If you are using an IP address or fully-qualified domain name instead of
    localhost, you will need to configure your firewall rules and allow access
-   only to ports 81 and 8001 for Archivematica usage.
+   only to ports 80 and 8000 for Archivematica usage.
 
 2. The Storage Service has its own set of users. Navigate to
    **Administration > Users** and add at least one administrative user. After


### PR DESCRIPTION
This clarifies the IP requirements for post-install configuration (centos, ubuntu,
and ansible), changing "public IP" to the more precise "an IP address or fully-
qualified domain name instead of local host."

Resolves #129.