### PR TITLE
Add disable output capturing docs

### DIFF
--- a/admin-manual/index.rst
+++ b/admin-manual/index.rst
@@ -18,6 +18,7 @@ set of links to each chapter's main sections.
    installation-setup/customization/customization
    installation-setup/customization/dashboard-config
    installation-setup/customization/antivirus-admin
+   installation-setup/customization/task-config
    installation-setup/integrations/integrations
    installation-setup/integrations/duracloud-setup
    installation-setup/integrations/atom-setup

--- a/admin-manual/installation-setup/customization/customization.rst
+++ b/admin-manual/installation-setup/customization/customization.rst
@@ -10,6 +10,7 @@ Customization and automation
 * :ref:`Preservation planning configuration <config-using-fpr>`
 * :ref:`Antivirus configuration <antivirus-config>`
 * :ref:`Resources for development configuration <development-config>`
+* :ref:`Task output capturing configuration <task-config>`
 
 .. _config-using-dashboard:
 
@@ -60,5 +61,24 @@ wiki:
 For other development resources, please see the
 `Development <https://www.archivematica.org/wiki/Development>`_ section of our
 wiki.
+
+.. _task-config:
+
+Task output capturing configuration
+-----------------------------------
+
+When Archivematica's MCP client (a Gearman worker) runs a client script in
+order to perform a preservation task, e.g., normalizing a single file, that
+client script may write data to standard streams, i.e., standard output
+(stdout) or standard error (stderr). By default, the worker serializes those
+outputs and sends them back to the MCP server (the task manager), at which
+point they are stored in the database (the ``Tasks`` table). However, in some
+cases these outputs may be quite large and the job of serializing and moving
+them around can have a noticeable performance impact. For this reason,
+Archivematica allows users to configure their MCP clients in order to control
+whether or not these output streams are captured. See
+:ref:`Task output capturing configuration <task-output-capturing-admin>` for
+more details.
+
 
 :ref:`Back to the top <customization>`

--- a/admin-manual/installation-setup/customization/task-config.rst
+++ b/admin-manual/installation-setup/customization/task-config.rst
@@ -1,0 +1,47 @@
+.. _task-output-capturing-admin:
+
+===================================
+Task output capturing configuration
+===================================
+
+Archivematica allows users to configure their MCP client(s) in order to control
+whether or not output streams (stdout and stderr) from the client scripts are
+captured and then passed from the task workers to the task manager (the MCP
+server).
+
+In the default configuration, these output streams *are* captured. In this
+state, when a user clicks on the gear icon of a micro-service in order to view
+the tasks that have run, each task representation will contain a section
+entitled ``Standard streams`` which will contain a sub-section entitled
+``Standard output (stdout)`` containing the stdout from the client script and
+another entitled ``Standard error (stderr)`` containing the stderr.
+
+However, in some cases, serializing these output streams and moving them around
+(*capturing* them) can have a non-trivial performance cost. (We have measured a
+6% reduction in processing time for some transfers when output capturing is
+disabled.) Archivematica can be configured to avoid paying this cost by
+disabling the capturing of these output streams. The trade-off for doing this
+is that the stdout and stderr that documents the running of a preservation task
+will no longer be stored in the database and it will no longer be displayed in
+the tasks interface.
+
+In order to configure Archivematica to stop capturing output streams, one must
+set the ``ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CAPTURE_CLIENT_SCRIPT_OUTPUT``
+environment variable to ``false`` before starting (or re-starting) the MCP
+client process. The way that Archivematica environment variables are set
+depends on the deployment method used. Please consult the relevant
+documentation for your deployment method if you are interested in disabling
+output capturing.
+
+- :ref:`Environment variable configuration for CentOS package-based installations <install-pkg-centos>`
+- :ref:`Environment variable configuration for Ubuntu package-based installations <install-pkg-ubuntu>`
+- :ref:`Environment variable configuration for Ubuntu Ansible-based installations <install-ansible>`
+- `Environment variable configuration for Docker Compose installations <https://github.com/artefactual-labs/am/tree/master/compose>`_
+
+Note that when output capturing is disabled the stdout will *never* be captured
+while the *stderr* will only be captured when the preservation task returns a
+non-zero exit code (i.e., when it fails). This allows the user to get the
+performance benefits while still having useful debugging information in the
+case where a task fails.
+
+:ref:`Back to the top <task-output-capturing-admin>`

--- a/admin-manual/installation-setup/installation/installation.rst
+++ b/admin-manual/installation-setup/installation/installation.rst
@@ -192,6 +192,8 @@ individual user. We have documented some common advanced installation setups.
 * :ref:`Installing for development <development>`
 * :ref:`Installing across multiple machines <multiple-machines>`
 * :ref:`Configure Archivematica with SSL <SSL-support>`
+* :ref:`Configure Archivematica with task output capturing disabled <task-output-capturing-admin>`
+
 
 :ref:`Back to the top <installation>`
 

--- a/admin-manual/installation-setup/upgrading/upgrading.rst
+++ b/admin-manual/installation-setup/upgrading/upgrading.rst
@@ -11,6 +11,7 @@ Upgrade from Archivematica |previous_version|.x to |release|
 * :ref:`Upgrade CentOS/Red Hat package install <upgrade-centos>`
 * :ref:`Upgrade search indices <upgrade-search-indices>`
 * :ref:`Upgrade in indexless mode <upgrade-indexless>`
+* :ref:`Upgrade with output capturing disabled <upgrade-no-output-capture>`
 
 .. note::
 
@@ -352,6 +353,22 @@ tabs do not appear and their functionality is not available.
 
       sudo -u root systemctl stop elasticsearch
       sudo -u root systemctl disable elasticsearch
+
+.. _upgrade-no-output-capture:
+
+Upgrade with output capturing disabled
+--------------------------------------
+
+As of Archivematica 1.7.1, output capturing can be disabled at upgrade or at
+any other time. This means the stdout and stderr from preservation tasks are
+not captured, which can result in a performane improvement. See the
+`Task output capturing configuration <task-output-capturing-admin>` page for
+more details. In order to disable output capturing, set the
+``ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_CAPTURE_CLIENT_SCRIPT_OUTPUT`` environment
+variable to ``false`` and restart the MCP Client process(es). Consult the
+installation instructions for your deployment method for more details on how to
+set environment variables and restart Archivematica processes.
+
 
 :ref:`Back to the top <upgrade>`
 


### PR DESCRIPTION
Adds documentation about the new *disable output capturing* feature.

Fixes #153 

- Adds a new page under customization/ entitled *Task output capturing configuration*
- Adds a section in customization/customization.rst about output capturing configuration which links to the new page.
- Adds a link in installation/installation.rst to the new page.
- Adds a link in upgrading/upgrading.rst to the new page.

**Note: this PR presumes the existence of sections in the relevant installation pages that describe how to set environment variables in order to configure Archivematica. These sections do not yet exist. A PR for issue #51 is required for this and the links in this PR may need to be slightly modified as a result.**