### PR TITLE
Updates error reporting page

### DIFF
--- a/getting-started/troubleshooting/error-reporting.rst
+++ b/getting-started/troubleshooting/error-reporting.rst
@@ -4,16 +4,21 @@
 Error reporting
 ===============
 
+.. important::
+
+   If you find a security vulnerability, do NOT open an issue. Email
+   info@artefactual.com instead.
+
 When an error or bug is encountered, we request that Archivematica users:
 
 1. Search the `User Forum <https://groups.google.com/forum/#!forum/archivematica>`_
    for similar problems and post a new thread if necessary.
 
-2. Search and/or report in our issue tracker. We use a Github repository to
+2. Search and/or report in our issue tracker. We use a GitHub repository to
    track issues for Archivematica: https://github.com/archivematica/Issues/
 
 You will need a
-`Github account <https://github.com/join?source=experiment-header-dropdowns-home>`_
+`GitHub account <https://github.com/join?source=experiment-header-dropdowns-home>`_
 to file a new issue or comment on an existing one. Optionally, you can also
 join the Archivematica Issues-Committers team to add labels to issues and edit
 the Issues Wiki. Please see the

--- a/getting-started/troubleshooting/error-reporting.rst
+++ b/getting-started/troubleshooting/error-reporting.rst
@@ -4,70 +4,19 @@
 Error reporting
 ===============
 
-When an error or bug is encountered, we request that Archivematica users first:
+When an error or bug is encountered, we request that Archivematica users:
 
-1. Search the `User Forum <https://groups.google.com/forum/#!forum/archivematica>`_    for similar problems and post a new thread if necessary.
+1. Search the `User Forum <https://groups.google.com/forum/#!forum/archivematica>`_
+   for similar problems and post a new thread if necessary.
 
-2. Search and/or report in our issue tracker. Artefactual uses Redmine project    management software to track bugs and issues in Archivematica. You can find    our Redmine instance at https://projects.artefactual.com
+2. Search and/or report in our issue tracker. We use a Github repository to
+   track issues for Archivematica: https://github.com/archivematica/Issues/
 
-Register for an account
------------------------
-
-You can register for an account in Redmine at:
-https://projects.artefactual.com/account/register
-
-If you are a client of Artefactual, you likely already have an account. Email
-support@artefactual.com if you need assistance.
-
-Search for a bug or issue
--------------------------
-
-Anyone can search Redmine for an existing issue or bug. Visit
-https://projects.artefactual.com and enter your search keywords.
-
-You can also browse Archivematica issues here:
-https://projects.artefactual.com/projects/archivematica/issues
-
-Note that issues or bugs related to client-specific development will not
-appear if you are not logged in, and further if your account is not associated
-with that project.
-
-Create a new bug or issue
--------------------------
-
-1. Always search Redmine for an existing bug or issue before reporting a new one.
-
-2. To create a new bug or issue, navigate to the Archivematica project by clicking on "Jump to a project" and then "Archivematica".
-
-3. Click on "New Issue" and fill in the required fields as outlined below:
-
-**Tracker**
-
-Choose "Bug" for an issue with an existing feature, or "Feature" to suggest a
-new functionality to Archivematica.
-
-**Subject**
-
-Provide a brief description of the bug or feature you are requesting.
-To help us avoid duplication, try to make your title clear and descriptive.
-
-**Description**
-
-Helpful information to include in the Description field are the steps to
-reproduce the bug or behaviour you are experiencing.
-
-**Status**
-
-Leave as New.
-
-**Priority**
-
-Please leave at Medium. Artefactual staff will triage the bug or feature as
-appropriate.
-
-**Other fields**
-
-Please leave blank and Artefactual staff will update as appropriate.
-
+You will need a
+`Github account <https://github.com/join?source=experiment-header-dropdowns-home>`_
+to file a new issue or comment on an existing one. Optionally, you can also
+join the Archivematica Issues-Committers team to add labels to issues and edit
+the Issues Wiki. Please see the
+`Issues wiki <https://github.com/archivematica/Issues/wiki>`_ for more details.
 
 :ref:`Back to the top <error-reporting>`


### PR DESCRIPTION
This update shortens the error reporting page to describe the issues repository
in Github and directs readers to the Issues Wiki for further details.

Connected to archivematica/Issues#15