### PR TITLE
Update CentOS packaging details to 1.8 

### DIFF
--- a/admin-manual/installation-setup/installation/install-centos.rst
+++ b/admin-manual/installation-setup/installation/install-centos.rst
@@ -69,24 +69,24 @@ Installation instructions
    * Archivematica:
 
    Use these commands to install the repositories:
-
+      
    .. code:: bash
-
+      
       sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica.repo
       [archivematica]
       name=archivematica
-      baseurl=https://packages.archivematica.org/1.7.x/centos
+      baseurl=https://packages.archivematica.org/1.8.x/centos
       gpgcheck=1
-      gpgkey=https://packages.archivematica.org/1.7.x/key.asc
+      gpgkey=https://packages.archivematica.org/1.8.x/key.asc
       enabled=1
       EOF'
-
+      
       sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica-extras.repo
       [archivematica-extras]
       name=archivematica-extras
-      baseurl=https://packages.archivematica.org/1.7.x/centos-extras
+      baseurl=https://packages.archivematica.org/1.8.x/centos-extras
       gpgcheck=1
-      gpgkey=https://packages.archivematica.org/1.7.x/key.asc
+      gpgkey=https://packages.archivematica.org/1.8.x/key.asc
       enabled=1
       EOF'
 

--- a/admin-manual/installation-setup/installation/install-centos.rst
+++ b/admin-manual/installation-setup/installation/install-centos.rst
@@ -69,9 +69,9 @@ Installation instructions
    * Archivematica:
 
    Use these commands to install the repositories:
-      
+
    .. code:: bash
-      
+   
       sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica.repo
       [archivematica]
       name=archivematica

--- a/admin-manual/installation-setup/installation/install-centos.rst
+++ b/admin-manual/installation-setup/installation/install-centos.rst
@@ -71,7 +71,7 @@ Installation instructions
    Use these commands to install the repositories:
 
    .. code:: bash
-   
+
       sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica.repo
       [archivematica]
       name=archivematica
@@ -80,7 +80,7 @@ Installation instructions
       gpgkey=https://packages.archivematica.org/1.8.x/key.asc
       enabled=1
       EOF'
-      
+
       sudo -u root bash -c 'cat << EOF > /etc/yum.repos.d/archivematica-extras.repo
       [archivematica-extras]
       name=archivematica-extras

--- a/admin-manual/installation-setup/upgrading/upgrading.rst
+++ b/admin-manual/installation-setup/upgrading/upgrading.rst
@@ -178,7 +178,7 @@ Upgrade on CentOS/Red Hat
 
    .. code:: bash
 
-      sudo sed -i 's/1.6.x/1.7.x/g' /etc/yum.repos.d/archivematica*
+      sudo sed -i 's/1.7.x/1.8.x/g' /etc/yum.repos.d/archivematica*
 
 2. Upgrade the packages:
 


### PR DESCRIPTION
Update Installation instructions (update url for packages from 1.7 to 1.8)
Update the Upgrade instructions (update the command to go from 1.7 to 1.8)

connected to https://github.com/archivematica/Issues/issues/203
(This PR only partially resolves that issue as it only covers CentOS. Another PR will be required to update details for Ubuntu.)