### PR TITLE
Add email configuration info to customization docs

### DIFF
--- a/admin-manual/installation-setup/customization/customization.rst
+++ b/admin-manual/installation-setup/customization/customization.rst
@@ -6,7 +6,7 @@ Customization and automation
 
 *On this page*
 
-* :ref:`Configuring microservices using the dashboard <config-using-dashboard>`
+* :ref:`Automating microservice decisions using the dashboard <config-using-dashboard>`
 * :ref:`Preservation planning configuration <config-using-fpr>`
 * :ref:`Antivirus configuration <antivirus-config>`
 * :ref:`Resources for development configuration <development-config>`
@@ -14,71 +14,115 @@ Customization and automation
 
 .. _config-using-dashboard:
 
-Configuring microservices using the dashboard
----------------------------------------------
+Automating microservice decisions using the dashboard
+-----------------------------------------------------
 
 It is possible for administrators or end-users to automate almost all of
-Archivematica's microservices by preconfiguring choices using the
-:ref:`Administration tab <dashboard-config>` of the dashboard.
+Archivematica's workflow decision points by changing the default processing
+configuration through the Administration tab. For more information, please see
+:ref:`Processing configuration <process-config>`.
+
+You can also automate workflow choices by placing a ``processingMCP.xml`` file
+into the root directory of your transfer. For more information about the
+processingMCP file and how to use it, please see :ref:`Using a custom processing
+configuration file <processingmcp-file>`.
 
 .. _config-using-fpr:
 
 Preservation planning configuration
 -----------------------------------
 
-The Preservation Planning tab allows editing or addition of commands for
-identification, tools, characterization, event detail, extraction,
-normalization, transcription, validation and verification. Please see the
-:ref:`Preservation Planning <preservation-planning>` for more information.
+The Preservation Planning tab allows users to edit, add, or disable commands for
+a variety of preservation tasks, including identification, characterization,
+normalization, validation, and verification. Please see the :ref:`Preservation
+Planning <preservation-planning>` documentation for more information.
 
 .. _antivirus-config:
 
 Antivirus configuration
 -----------------------
 
-Antivirus can be customized through various operating system environment
-variables rather than via the Dashboard. See :ref:`Antivirus Administration
-<antivirus-admin>`
+Archivematica's antivirus capabilities can be customized by editing various
+operating system environment variables. Please see :ref:`Antivirus
+Administration <antivirus-admin>` for more information.
+
+.. _email-config:
+
+Email notification configuration
+--------------------------------
+
+Archivematica's MCPClient sends two types of email reports:
+
+* Normalization reports are sent when the normalization process has resulted in
+  at least one error.
+* Failure reports are sent when the workflow fails unexpectedly.
+
+The email reports are sent to all users who have an account on the pipeline.
+Currently, there is no way to configure which users receive the email. If you
+don't want a user to receive the email, the easiest way to disable this is to
+change the email address associated with the user to an invalid one.
+
+If you are running a QA environment, it is possible that your only registered
+user is ``demo@example.com``. Be aware that Archivematica ignores this address
+and will not send notifications to it. If you want to test the email reporting
+functionality make sure to register a functional email address for a user.
+
+Currently, emails are only sent by MCPClient. This means that in order to
+configure the email backend settings, changes are required in the MCPClient
+service configuration. For example, you can use the following environment
+strings to send emails via a local MTA such as Postfix::
+
+    ARCHIVEMATICA_MCPCLIENT_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+    ARCHIVEMATICA_MCPCLIENT_EMAIL_HOST=127.0.0.1
+    ARCHIVEMATICA_MCPCLIENT_EMAIL_PORT=25
+
+For more information about configuring the MCPClient, please see the
+`MCPClient configuration documentation`_.
+
+Archivematica sends emails using the Django Web Framework. You can install
+third-party packages like ``django-ses`` to support additional email backends.
+Packages must be installed in the Python environment of MCPClient.
 
 .. _development-config:
 
 Resources for development configuration
 ---------------------------------------
 
-When processing a SIP or transfer, you may automate workflow choices by putting
-a ``processingMCP.xml`` file into the root directory of a SIP/transfer. See
-:ref:`Processing configuration <process-config>`.
+If you are working on developing Archivematica, it may be helpful to
 
-The MCP is the core of the Archivematica system. It controls the various
-micro-services in the Archivematica system. Developers who wish to modify the
-MCP configuration should consult the following resources on the Archivematica
-wiki:
+A common area for development work is the MCP (Master Control Program). The MCP
+is the core of Archivematica, and controls the various micro-services that
+Archivematica uses to carry out preservation tasks. Developers who wish to
+modify the MCP configuration should consult the following resources on the
+Archivematica wiki:
 
-* `MCP <https://www.archivematica.org/wiki/MCP>`_
+* `MCP`_
+* `Basic MCP configuration`_
 
-* `Basic MCP configuration <https://wiki.archivematica.org/MCPServer#Config_File>`_
-
-For other development resources, please see the
-`Development <https://www.archivematica.org/wiki/Development>`_ section of our
-wiki.
+For other development resources, please see the `Development`_ section of the
+Archivematica wiki.
 
 .. _task-config:
 
 Task output capturing configuration
 -----------------------------------
 
-When Archivematica's MCP client (a Gearman worker) runs a client script in
-order to perform a preservation task, e.g., normalizing a single file, that
-client script may write data to standard streams, i.e., standard output
-(stdout) or standard error (stderr). By default, the worker serializes those
-outputs and sends them back to the MCP server (the task manager), at which
-point they are stored in the database (the ``Tasks`` table). However, in some
-cases these outputs may be quite large and the job of serializing and moving
-them around can have a noticeable performance impact. For this reason,
-Archivematica allows users to configure their MCP clients in order to control
-whether or not these output streams are captured. See
-:ref:`Task output capturing configuration <task-output-capturing-admin>` for
-more details.
+When Archivematica's MCP client (a Gearman worker) runs a client script in order
+to perform a preservation task, e.g., normalizing a single file, that client
+script may write data to standard streams, i.e., standard output (stdout) or
+standard error (stderr). By default, the worker serializes those outputs and
+sends them back to the MCP server (the task manager), at which point they are
+stored in the database (the ``Tasks`` table). However, in some cases these
+outputs may be quite large and the job of serializing and moving them around can
+have a noticeable performance impact. For this reason, Archivematica allows
+users to configure their MCP clients in order to control whether or not these
+output streams are captured. See :ref:`Task output capturing configuration
+<task-output-capturing-admin>` for more details.
 
 
 :ref:`Back to the top <customization>`
+
+.. _`MCP`: https://www.archivematica.org/wiki/MCP
+.. _`Basic MCP configuration`: https://wiki.archivematica.org/MCPServer#Config_File
+.. _`Development`: https://www.archivematica.org/wiki/Development
+.. _MCPClient configuration documentation: https://github.com/artefactual/archivematica/blob/qa/1.x/src/MCPClient/install/README.md

--- a/getting-started/troubleshooting/error-handling.rst
+++ b/getting-started/troubleshooting/error-handling.rst
@@ -48,7 +48,7 @@ Dashboard error reporting
 
 When a micro-service fails or encounters an error, the workflow will be halted
 and Archivematica will report a 'Failed transfer'. The micro-service drop-down
-can be expanded to show the specific task that failed. 
+can be expanded to show the specific task that failed.
 
 .. figure:: images/PinkChecksumFail.*
    :align: center
@@ -57,7 +57,7 @@ can be expanded to show the specific task that failed.
    :alt: The dashboard showing a transfer has failed
 
    The dashboard showing a transfer has failed at the Verify transfer checksums
-   micro-service 
+   micro-service
 
 Note that the transfer has been moved to the failed directory and processing
 has been halted.
@@ -101,8 +101,11 @@ more information.
 Email error report
 ------------------
 
-If the user has an email address associated with their user account, the
-dashboard can email a failure report:
+Archivematica will send email reports for two kinds of failures:
+
+* Normalization reports are sent when the normalization process has resulted in
+  at least one error.
+* Failure reports are sent when the workflow fails unexpectedly.
 
 .. figure:: images/EmailFail-10.*
    :align: center
@@ -116,6 +119,9 @@ An e-mail is generated if the transfer or ingest cannot be completed, not if
 an error occurs which does not halt processing. Please note that the server
 must have mail delivery enabled in order to receive error emails without
 additional configuration.
+
+For more information about email reports, please see :ref:`Email notification
+configuration <email-config>`
 
 .. _normalization-errors:
 
@@ -192,8 +198,8 @@ based on FITS-DROID results instead.
 
    Redo normalization option in drop-down menu of Approve normalization job
 
-Archivematica will send an email when normalization errors occur. Information given
-in the email report:
+Archivematica will send an :ref:`email <email-failure>` when normalization
+errors occur. Information given in the email report:
 
 * UUID of the pipeline
 * Name and UUID of the SIP

--- a/getting-started/troubleshooting/faq.rst
+++ b/getting-started/troubleshooting/faq.rst
@@ -39,11 +39,11 @@ FAQ
 #. **What does Archivematica do?**
 
    The main purpose of Archivematica is to create standards-based, self-documenting
-   and system-independent archival information packages (AIPs). An AIP includes 
-   a METS XML file with a robust PREMIS preservation metadata implementation, 
-   and is packaged in the Library of Congress BagIt format, which includes file 
-   manifests and information about the AIP contents. The physical and logical 
-   structure of the AIP is described in the METS structMap. 
+   and system-independent archival information packages (AIPs). An AIP includes
+   a METS XML file with a robust PREMIS preservation metadata implementation,
+   and is packaged in the Library of Congress BagIt format, which includes file
+   manifests and information about the AIP contents. The physical and logical
+   structure of the AIP is described in the METS structMap.
 
 #. **Does Archivematica perform fixity checks?**
 
@@ -73,39 +73,39 @@ FAQ
 
 #. **What is Archivematica’s capacity?  How much can it handle?**
 
-   Capacity is highly dependent on the resources allocated to the servers on 
-   which the software is installed. Archivematica has been successfully tested 
-   with SIPs of 100,000 files and with video files of several TB each. No maximum 
-   size or number of files can be specified; Artefactual works with clients to 
-   determine optimal use cases and workflows on a per-institution basis. 
+   Capacity is highly dependent on the resources allocated to the servers on
+   which the software is installed. Archivematica has been successfully tested
+   with SIPs of 100,000 files and with video files of several TB each. No maximum
+   size or number of files can be specified; Artefactual works with clients to
+   determine optimal use cases and workflows on a per-institution basis.
 
 #. **What is the format and structure of the Archival Information Package (AIP)?**
 
-   The `Archivematica AIP <https://www.archivematica.org/en/docs/archivematica-1.6/user-manual/archival-storage/aip-structure/#aip-structure>`_ consists primarily of the 
-   ingested objects, any preservation masters generated during processing, and 
-   technical, preservation, audit and descriptive metadata encoded in METS XML. 
-   The METS file contains a robust PREMIS implementation, including the Object, 
-   Event, Agent and Rights entities. Dublin Core is supported as a descriptive 
-   metadata standard. 
+   The `Archivematica AIP <https://www.archivematica.org/en/docs/archivematica-1.6/user-manual/archival-storage/aip-structure/#aip-structure>`_ consists primarily of the
+   ingested objects, any preservation masters generated during processing, and
+   technical, preservation, audit and descriptive metadata encoded in METS XML.
+   The METS file contains a robust PREMIS implementation, including the Object,
+   Event, Agent and Rights entities. Dublin Core is supported as a descriptive
+   metadata standard.
 
 #. **What kinds of preservation metadata is included in an AIP’s METS XML file?**
 
-   Archivematica by default includes a very robust PREMIS implementation which 
-   includes the Object, Event, Agent and Rights entities. Standard Events include 
-   ingestion, fixity check, message digest calculation,  unpacking, decompression, 
-   virus check, format identification, format validation and normalization. The 
-   names of the software platform, the organization and the logged-in user are 
-   captured as Agents for each Event. Rights statements can be ingested as csv 
-   metadata or added by the user via a metadata-entry template during processing.   
+   Archivematica by default includes a very robust PREMIS implementation which
+   includes the Object, Event, Agent and Rights entities. Standard Events include
+   ingestion, fixity check, message digest calculation,  unpacking, decompression,
+   virus check, format identification, format validation and normalization. The
+   names of the software platform, the organization and the logged-in user are
+   captured as Agents for each Event. Rights statements can be ingested as csv
+   metadata or added by the user via a metadata-entry template during processing.
 
 #. **Can I appraise and arrange records in Archivematica?**
 
-   Yes! In Archivematica 1.6 an appraisal dashboard allows the user to perform 
-   archival appraisal and arrangement activities on ingested files. Submission 
-   documentation such as donor agreements, transfer forms and accession records 
-   can be added to the SIP for preservation along with the ingested digital objects, 
-   and are identified as submission documentation in the preservation metadata 
-   in the AIP. In AtoM, an accessions module allows users to record accessions, 
+   Yes! In Archivematica 1.6 an appraisal dashboard allows the user to perform
+   archival appraisal and arrangement activities on ingested files. Submission
+   documentation such as donor agreements, transfer forms and accession records
+   can be added to the SIP for preservation along with the ingested digital objects,
+   and are identified as submission documentation in the preservation metadata
+   in the AIP. In AtoM, an accessions module allows users to record accessions,
    accruals and deaccessions and to record information about appraisal and selection.
 
 #. **Why doesn't Archivematica have a module for providing access to digital
@@ -126,54 +126,55 @@ FAQ
    possible; see the next question below.
 
 #. **Can I describe content in Archivematica?**
-   
+
    You can ingest metadata as a CSV file or through the dashboard while processing.
    However, Archivematica is not an archival description system.  In-depth
-   contextual and content description can be done through an access system like 
+   contextual and content description can be done through an access system like
    AtoM.
 
 #. **How does Archivematica prevent viruses?**
 
-   All ingested content is automatically scanned for viruses and malware using 
-   clamAV, a well-established open-source software tool that comes bundled with 
+   All ingested content is automatically scanned for viruses and malware using
+   clamAV, a well-established open-source software tool that comes bundled with
    Archivematica. Virus definitions are updated on a regular basis.
 
 #. **What is normalization and how does normalization work?**
 
-   Transcoding, or normalization, is automated through the use of preservation 
-   commands entered into the `Format Policy Registry <https://www.archivematica.org/en/docs/archivematica-1.6/user-manual/preservation/preservation-planning/#fpr>`_. 
-   Bundled tools for transcoding include ffmpeg, Inkscape, Ghostscript and 
-   ImageMagick. The FPR comes with hundreds of format-specific commands which 
+   Transcoding, or normalization, is automated through the use of preservation
+   commands entered into the `Format Policy Registry <https://www.archivematica.org/en/docs/archivematica-1.6/user-manual/preservation/preservation-planning/#fpr>`_.
+   Bundled tools for transcoding include ffmpeg, Inkscape, Ghostscript and
+   ImageMagick. The FPR comes with hundreds of format-specific commands which
    can be edited by the user.
 
 #. **How do I know if there are errors during ingest?**
-  
-   Errors are indicated in the Archivematica dashboard during processing. Alerts 
-   can also be emailed to designated users and certain types of error reports 
-   are retained in the Administration tab of the dashboard. The corrective action 
-   will depend on the nature of the error; examples include rejecting the transfer 
-   or SIP and starting again, accepting the error and continuing the process, 
-   taking corrective action and re-running the micro-service or troubleshooting 
-   the issue through the command-line.
+
+   Errors are indicated in the Archivematica dashboard during processing. Alerts
+   can also be :ref:`emailed <email-config>` to designated users and certain
+   types of error reports  are retained in the Administration tab of the
+   dashboard. The corrective action  will depend on the nature of the error;
+   examples include rejecting the transfer  or SIP and starting again, accepting
+   the error and continuing the process,  taking corrective action and
+   re-running the micro-service or troubleshooting  the issue through the
+   command-line.
 
 #. **I need to use Archivematica in conjunction with another system (for access,
    storage, etc). How can I integrate the two systems?**
 
-   The list of systems and tools that Archivematica is integrated with grows with 
-   almost every release. If you are interested in having Archivematica integrate 
+   The list of systems and tools that Archivematica is integrated with grows with
+   almost every release. If you are interested in having Archivematica integrate
    with a system which is not currently on our `Roadmap <https://www.archivematica.org/wiki/Development_roadmap:_Archivematica>`_, here are a few ideas:
 
-  * Post to the `user forum <https://groups.gtoogle.com/forum/#!forum/archivematica>`_ 
-    and ask community members if they have any experience creating a workflow 
+  * Post to the `user forum <https://groups.gtoogle.com/forum/#!forum/archivematica>`_
+    and ask community members if they have any experience creating a workflow
     between Archivematica and the other system.
 
-  * If you have software development skills, consider writing to code required 
-    to integrate the two systems. If practical, we would gladly accept the code 
-    into the Archivematica code base via a 
+  * If you have software development skills, consider writing to code required
+    to integrate the two systems. If practical, we would gladly accept the code
+    into the Archivematica code base via a
     `pull request <https://www.archivematica.org/wiki/Contribute_code>`_ .
 
-  * Contract Artefactual Systems to `write the code <http://www.artefactual.com/services/development/>`_. 
-    We will work with you to identify requirements and include the new integration 
+  * Contract Artefactual Systems to `write the code <http://www.artefactual.com/services/development/>`_.
+    We will work with you to identify requirements and include the new integration
     code in the next software release, for the entire community's benefit.
 
 


### PR DESCRIPTION
This change adds information on how to configure the email notifications
that users receive for normalization issues and processing failures. I've also
added a few references to this section from other relevant sections of the
documentation.

Connected to artefactual/archivematica#1128