### PR TITLE
Add Scaling Archivematica documentation

### DIFF
--- a/admin-manual/index.rst
+++ b/admin-manual/index.rst
@@ -19,6 +19,7 @@ set of links to each chapter's main sections.
    installation-setup/customization/dashboard-config
    installation-setup/customization/antivirus-admin
    installation-setup/customization/task-config
+   installation-setup/customization/scaling-archivematica
    installation-setup/integrations/integrations
    installation-setup/integrations/duracloud-setup
    installation-setup/integrations/atom-setup

--- a/admin-manual/installation-setup/customization/customization.rst
+++ b/admin-manual/installation-setup/customization/customization.rst
@@ -12,6 +12,7 @@ Customization and automation
 * :ref:`Antivirus configuration <antivirus-config>`
 * :ref:`Resources for development configuration <development-config>`
 * :ref:`Task output capturing configuration <task-config>`
+* :ref:`Customizing for scalability and performance <customize-scalability>`
 
 .. _config-admin-tab:
 
@@ -131,10 +132,24 @@ users to configure their MCP clients in order to control whether or not these
 output streams are captured. See :ref:`Task output capturing configuration
 <task-output-capturing-admin>` for more details.
 
+.. _customize-scalability:
+
+Customizing for scalability and performance
+-------------------------------------------
+
+Archivematica includes a number of features and options to improve scalability
+& performance. The default configuration options are geared towards “typical” 
+use cases and for many users won’t require any modification. However, some 
+users will benefit from optimizing configuration options to meet their 
+specific preservation needs & available computing resources.
+
+See :ref:`Scaling Archivematica <scaling-archivematica>` for a description of 
+three broad approaches to scaling & optimization and the specific techniques 
+available to each approach. 
 
 :ref:`Back to the top <customization>`
 
 .. _`MCP`: https://www.archivematica.org/wiki/MCP
 .. _`Basic MCP configuration`: https://wiki.archivematica.org/MCPServer#Config_File
 .. _`Development`: https://www.archivematica.org/wiki/Development
-.. _MCPClient configuration documentation: https://github.com/artefactual/archivematica/blob/qa/1.x/src/MCPClient/install/README.md
+.. _`MCPClient configuration documentation`: https://github.com/artefactual/archivematica/blob/qa/1.x/src/MCPClient/install/README.md

--- a/admin-manual/installation-setup/customization/customization.rst
+++ b/admin-manual/installation-setup/customization/customization.rst
@@ -138,8 +138,8 @@ Customizing for scalability and performance
 -------------------------------------------
 
 Archivematica includes a number of features and options to improve scalability
-& performance. The default configuration options are geared towards “typical” 
-use cases and for many users won’t require any modification. However, some 
+& performance. The default configuration options are geared towards "typical" 
+use cases and for many users won't require any modification. However, some 
 users will benefit from optimizing configuration options to meet their 
 specific preservation needs & available computing resources.
 

--- a/admin-manual/installation-setup/customization/scaling-archivematica.rst
+++ b/admin-manual/installation-setup/customization/scaling-archivematica.rst
@@ -1,0 +1,396 @@
+.. _scaling-archivematica:
+
+=====================
+Scaling Archivematica
+=====================
+
+.. _scaling-overview:
+
+Overview
+--------
+
+Archivematica includes a number of features and options to improve scalability
+& performance. The default configuration options are geared towards “typical” 
+use cases and for many users won’t require any modification. However, some 
+users will benefit from optimizing configuration options to meet their 
+specific preservation needs & available computing resources.
+
+This guide describes three broad approaches to scaling & optimization and the 
+specific techniques available to each approach. 
+
+This is not a detailed ‘how to’ guide or set of specific recommendations. The 
+goal here is to explain what broad strategies are available and enough of the 
+implementation details to allow skilled administrators to choose and implement 
+the right strategy for their institution. 
+
+*On this page:* 
+* :ref:`Scaling up: optimising on one machine <scaling-up>` 
+* :ref:`Scaling out: optimising across multiple machines <scaling-out>`
+* :ref:`Process configuration strategies <config-strategies>` 
+
+.. _scaling-up:
+
+Scaling up: optimising on one machine
+-------------------------------------
+
+Processing speed and capacity will generally increase in line with increases 
+in computing resources (CPU, memory & disk space). When a deployment uses a 
+machine with considerably more (or less) resources than the 
+:ref:`recommended minimum production requirements <requirements-production>`, 
+there are several different configuration options that may help further 
+optimize performance. 
+
+Limit task threads in MCPServer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The MCPServer can accept instructions to process work from multiple sources 
+(e.g. the Dashboard, API, a watched directory) and will create new threads as
+new instructions are received, up to a defined limit. The limit helps to 
+mitigate the risk of concurrency errors (conflicts or contention when the 
+machine is trying to do too many things at once). 
+
+The ``ARCHIVEMATICA_MCPSERVER_PROTOCOL_LIMITTASKTHREADS`` parameter defines the 
+maximum number of threads that MCPServer will run simultaneously. The default 
+value is 75. This number could be increased on machines with a large number of
+CPUs or decreased on machines with very few (2) CPUs. See `MCPServer`_ 
+for details. 
+
+Deploy multiple MCPClients
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `MCPClient`_ component is responsible for the most significant sources of 
+load in an Archivematica deployment. In Archivematica 1.8.x and higher, it can 
+in some cases make sense to deploy more than one MCPClient component on the 
+same machine, due to the introduction of batching. 
+
+.. note::
+
+   Note: In Archivematica 1.7.x and earlier, the MCPClient does not use 
+   batching, and instead creates multiple Gearman workers (creating one worker
+   per CPU available). In these earlier versions, there is no benefit to 
+   installing multiple instances of the MCPClient on the same machine. There 
+   will still be a benefit in installing multiple instances on different 
+   machines. See 
+   :ref:`Scaling out: optimising across multiple machines <scaling-out>`.  
+
+The MCPClient accepts batches of files to process at once. Batches are 
+processed using a single process by default, but some client scripts can run
+multi-threaded or fork processes where possible (see `MCPClient concurrency`_
+for more details). This approach is a trade-off that delivers significant 
+improvements in most circumstances. 
+
+However, there will be times when certain tasks are not run concurrently, and 
+CPU becomes underutilized. Deploying multiple instances of the MCPClient 
+component may improve overall performance, particularly where a machine has 
+many CPUs. 
+
+To deploy another instance of MCPClient on the same machine we recommend 
+creating an additional `systemd`_ unit. A second unit can be created by 
+creating another `unit file`_ for the MCPClient service. For example, in CentOS 
+the existing `MCPClient unit file`_ is located in 
+`/etc/systemd/system/archivematica-mcp-client.service`.
+To add a unit, create a copy of that unit file with a different name, such as\
+`/etc/systemd/system/archivematica-mcp-client-two.service` 
+and ask systemd to reload all unit files using `$ systemctl daemon-reload`.  
+
+
+Optimize batch size for large files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``ARCHIVEMATICA_MCPSERVER_MCPSERVER_BATCH_SIZE`` parameter defines the 
+maximum number of files that will be included in any one batch. The default 
+value is 128, which is the threshold at which increasing batch size does not
+deliver further performance gains. 
+
+When processing large files, smaller batch sizes may improve performance when 
+there is more than one instance of MCPClient available. For example, processing
+large audio-visual files can take significant resources and time per file. A 
+transfer with 100 files in it will all get included in one batch assuming the 
+default batch size of 128. Reducing the batch size to 25 would result in 4 
+batches, which would all run concurrently if there were 4 instances of the 
+MCPClient available. 
+
+Currently we do not have detailed recommendations on for optimizations of this 
+type. We encourage testing and evaluation to find the best settings for your 
+circumstances. 
+
+To set the batch size parameter, see `MCPServer`_ Configuration.
+
+.. _scaling-out:
+
+Scaling out: optimising across multiple machines 
+------------------------------------------------
+
+The second general strategy to improve processing speed and capacity is to 
+distribute some components in the system across more than one machine. This 
+section sets outs which components can be distributed to other machines and 
+describes the configuration options available for optimizing performance across
+those machines. 
+
+Distributing components on multiple machines
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Firewall configuration
+++++++++++++++++++++++
+
+When installing Archivematica on multiple machines, the various Archivematica
+processes must be able to reach each other on the relevant ports. Your firewall
+configuration must allow for this.
+
+In particular, please ensure that the Archivematica dashboard can talk to the
+Storage Service, and that the pipeline components (i.e., MCPServer, MCPClient)
+can talk to Gearman.
+
+In addition, please ensure that the Elasticsearch (``9200``) and MySQL
+(``3306``) services are not exposed to the world.
+
+The ports of the Archivematica components and related services are provided
+below.
+
+* Archivematica dashboard: ``80`` (``81`` for RPM-based installs)
+* Archivematica Storage Service: ``8000`` (``8001`` for RPM-based installs)
+* MySQL: ``3306``
+* Gearman: ``4730``
+* SSH: ``22``
+* Elasticsearch: ``9200``
+* NFS: ``2049``
+
+Create multiple instances of MCPClient (on a separate machine)
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+As noted above, the MCPClient is responsible for the most significant sources 
+of load on a machine. Creating instances of the MCPClient on other machines is 
+the most obvious way to improve concurrent processing. 
+
+To create another instance of an MCPClient on another machine: 
+
+#. Install the MCPClient using your preferred installation method: manually 
+   using packages, or by modifying ansible scripts or docker-compose scripts
+#. Ensure that the second machine has access to the following shared 
+   directories, defined in these parameters (see `MCPClient`_ Configuration 
+   for details):
+   ``ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_SHAREDDIRECTORYMOUNTED``
+   ``ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_PROCESSINGDIRECTORY``
+   ``ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_REJECTEDDIRECTORY``
+   ``ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_WATCHDIRECTORYPATH``
+#. Ensure the additional MCPClient instance is configured to connect to the 
+   Gearman server (on the original machine) by setting the following parameter: 
+   ``ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_MCPARCHIVEMATICASERVER``
+
+It is also possible to restrict an MCPClient to run certain types of tasks, by 
+editing the list of supported commands in the `archivematicaClientModules`_ 
+file. This might be advantageous where certain commands tend to be run on 
+certain kinds of objects, allowing you to route particular types of work to 
+specific MCPClients or machines. 
+ 
+Distribute other components to another machine 
+++++++++++++++++++++++++++++++++++++++++++++++
+
+It is possible to deploy the Elasticsearch, Gearman and MySQL components on 
+other machines.  
+For help, ask on the `Archivematica user forum`_ for more details.
+
+Optimizing settings across machines
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Optimize batch size for large files
++++++++++++++++++++++++++++++++++++
+
+This technique will work just as well on multiple machines as it does on one 
+machine, as described above in :ref:`Scaling up: optimising on one machine <scaling-up>`. 
+
+Adjusting timeouts
+++++++++++++++++++
+
+Timeout settings are an important tool to mitigate failure scenarios created 
+when one component can’t connect to another. The challenge is to set timeouts 
+so that they are long enough to allow particular processes to complete, but 
+not so long that system resources are left idle (or user’s time is wasted), 
+waiting for a response from another component that has failed or can’t be 
+reached due to network connectivity issues.  
+
+The standard timeout parameters for each component are used for long-running 
+(generally asynchronous) processes. “Quick” timeout values are for processes 
+that are synchronous and short (for instance, when an API is called to return 
+information to the UI for a waiting user). 
+
+The default value for the “Quick” timeouts is 120 seconds. This is optimal for 
+components that are located on the same machine, and will be adequate in many 
+cases for components that are distributed to machines that are co-located. 
+
+There may be times when timeout values should be increased for distributed 
+components that are not co-located, or are slower due to the nature of the 
+communication protocol used. 
+
+See `Dashboard`_ Configuration, `MCPClient`_ Configuration, and `MCPServer`_ 
+Configuration for a list of all timeout parameters, their default settings and 
+instructions for modifying them.  
+
+Optimizing storage locations
+++++++++++++++++++++++++++++
+
+The Storage Service Administrator manual describes the different types of 
+:ref:`storage locations <storageService:locations>` that Archivematica uses. 
+
+In many cases it may be necessary to use different machines for different types
+of storage locations. In general, we recommend having the most frequently used 
+locations (e.g. the “currently processing” location) on a local machine. 
+Locations that are used less frequently, such as AIP or DIP storage, will have 
+less impact on performance when distributed to remote storage locations.  
+
+.. _config-strategies:
+
+Process configuration strategies 
+--------------------------------
+
+Optimising what & how preservation actions get executed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The final strategy for improving the performance and capacity of your 
+Archivematica deployment is to ensure that Archivematica is only carrying out 
+the work you deem important and necessary. Archivematica provides a wide 
+range of preservation actions and the default settings tend to make use of the 
+majority of them. There are several techniques for limiting which actions are 
+taken, that can have a significant impact on the overall time & compute 
+required to process a particular Transfer or SIP. 
+
+Environment configuration options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Disable Elasticsearch indexing 
+++++++++++++++++++++++++++++++
+
+Archivematica uses Elasticsearch to create an index of every Archival 
+Information Package (AIP) it creates. It also creates an index of any Transfer 
+that is sent to the backlog. Indexes enable the search functionality from the 
+Archival Storage tab of the Dashboard (in the case of AIPs) or the Backlog and 
+Appraisal tabs (in the case of Transfers that were sent to the Backlog). 
+Indexes contain information on every object in a Transfer or AIP. 
+
+If a user chooses (whether in the dashboard or by configuration) to send 
+Transfers to the Backlog, the "Index Transfer Contents" job is run as part of 
+the "Create SIP From Transfer Microservice". At the end of the Ingest process 
+(in all cases) an Index is created as part of the "Store AIP" Microservice. 
+
+The larger a Transfer or AIP is, the longer it will take to create the Index. 
+Some users have found that Indexing can fail on very large Transfers or AIPS 
+(e.g. with many thousands of files). 
+
+Use of Elasticsearch is optional. Installing Archivematica without 
+Elasticsearch means reduced consumption of compute resources and lower 
+operational complexity. Disabling Elasticsearch means that the Backlog, 
+Appraisal, and Archival Storage tabs do not appear and their functionality is 
+not available.
+
+See :ref:`Upgrade in indexless mode <upgrade-indexless>` for more details. 
+
+Allow indexing to fail
+++++++++++++++++++++++
+
+Indexing very large datasets can be so resource-intensive that indexing will 
+fail. By default, Archivematica will abort processing and invoked the 
+“Failed SIP” microservice. 
+
+The ``ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_INDEX_AIP_CONTINUE_ON_ERROR`` parameter 
+can be set to allow indexing to fail. When this is set and indexing fails, 
+the AIP will carry on with processing and be stored. It can’t be found using 
+the normal search features in the Appraisal and Archival Storage tabs. 
+
+This feature doesn’t optimize performance so much as mitigate performance 
+limitations. See `MCPClient`_ Configuration for details. 
+
+Disabling task output
++++++++++++++++++++++
+
+Archivematica allows users to configure their MCPClient(s) in order to control 
+whether or not output streams (stdout and stderr) from the client scripts are 
+captured and then passed from the task workers to the task manager 
+(the MCPServer). Disabling task output will provide performance improvements. 
+
+See :ref:`Task output capturing configuration <task-output-capturing-admin>`.
+
+Processing configuration options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :ref:`Processing configuration <dashboard-processing>` screen provides many 
+options for controlling what actions Archivematica performs. The following 
+settings can improve performance. 
+
+**Select file format identification command (Transfer):** Using Siegfried for 
+file identification has been shown to be faster than Fido in this 
+`benchmarking`_ study.
+
+**Select file format identification command (Ingest):** If you are using the 
+Archivematica backlog and have accumulated items in the backlog for a long 
+period of time, e.g. months or even years, then you might want Archivematica to
+refresh its file format identification at the Ingest stage of the workflow. If
+Ingest is happening shortly after Transfer, selecting `Use existing data` 
+should be adequate and will save processing time. 
+
+**Generate thumbnails:** If you are generating thumbnails, selecting `yes 
+without defaults` will only generate thumbnail images for formats that have a 
+specific thumbnail rule defined. The default thumbnail rule only produces a 
+grey icon and for many formats has little value, but in transfers with many 
+files, can take significant processing time. 
+
+**Select compression algorithm:** AIP compression causes an AIP to be put into 
+a container (e.g. a 7Zip container).  Using containers makes AIP storage and 
+transfer easier because the AIP is easier to move around as a single file. The 
+AIP file size also has the potential to be reduced, which saves storage space 
+and speeds up transfers to external AIP stores. The disadvantage is that 
+compression can take significant processing time and resources. AIP compression 
+introduces three extra steps in the workflow: compression to create the 
+container, then decompression to allow for a final checksum validation step. In 
+transfers with very large numbers of files (thousands) we have seen significant
+performance improvements by not compressing the AIP.  
+
+**Select compression level:** Selecting a higher compression level means that 
+the resulting AIP is smaller, but compression also takes longer. Lower 
+compression levels mean quicker compression, but a larger AIP.
+
+Preservation Action Rules
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some of the default preservation action rules can take considerable processing 
+time and resources. We have found the following rules useful to change in some 
+cases. 
+
+**Turn off default characterization rule:** FITS is used to characterise files 
+that don't have a recognised file format. Executing this rule takes processing 
+time and adds raw output to the METS file that can be low value for some  
+formats. For example, in scientific datasets with large numbers of generic text 
+files, or binary files created by instruments in scientific experiments, the 
+output can be verbose without being useful. 
+
+**Reduce number of image characterization rules:** Archivematica has rules 
+defined for all image formats to use ExifTool, Mediainfo and ffprobe for 
+characterisation. Using multiple tools ensures as much characterization output 
+as possible, but also introduces some level of duplication. Only using one of 
+the three tools for certain formats may provide an adequate level of 
+characterization with the benefit of reducing processing time and the size of 
+the final AIP. 
+
+See :ref:`Characterization <characterization>` and 
+:ref:`Altering commands and rules <altering-commands-rules>` for more details.  
+
+General Configuration Settings  
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Checksum Algorithm:** In the :ref:`General settings <dashboard-general>` 
+screen you can select which checksum algorithm Archivematica will use during 
+the Assign UUIDs and checksums micro-service. For the purposes of fixity 
+checking, the MD5 algorithm is perfectly adequate and takes less processing 
+time to create (and check) than the alternatives (e.g. SHA-256). 
+
+:ref:`Back to the top <scaling-archivematica>`
+
+.. _`MCPServer`: https://github.com/artefactual/archivematica/tree/qa/1.x/src/MCPServer/install
+.. _`MCPClient`: https://github.com/artefactual/archivematica/tree/qa/1.x/src/MCPClient
+.. _`MCPClient concurrency` : https://github.com/artefactual/archivematica/tree/qa/1.x/src/MCPClient#concurrency
+.. _`systemd` : https://en.wikipedia.org/wiki/Systemd
+.. _`unit file` : https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+.. _`MCPClient unit file` : https://raw.githubusercontent.com/artefactual-labs/am-packbuild/qa/1.x/rpm/archivematica/etc/archivematica-mcp-client.service
+.. _`archivematicaClientModules` : https://github.com/artefactual/archivematica/blob/stable/1.7.x/src/MCPClient/lib/archivematicaClientModules
+.. _`Archivematica user forum` : https://groups.google.com/a/artefactual.com/forum/#!forum/archivematica
+.. _`Dashboard`: https://github.com/artefactual/archivematica/tree/qa/1.x/src/dashboard/install
+.. _`benchmarking` : https://www.itforarchivists.com/siegfried/benchmarks

--- a/admin-manual/installation-setup/customization/scaling-archivematica.rst
+++ b/admin-manual/installation-setup/customization/scaling-archivematica.rst
@@ -10,12 +10,12 @@ Overview
 --------
 
 Archivematica includes a number of features and options to improve scalability
-& performance. The default configuration options are geared towards "typical" 
+and performance. The default configuration options are geared towards "typical" 
 use cases and for many users won't require any modification. However, some 
 users will benefit from optimizing configuration options to meet their 
-specific preservation needs & available computing resources.
+specific preservation needs and available computing resources.
 
-This guide describes three broad approaches to scaling & optimization and the 
+This guide describes three broad approaches to scaling and optimization and the 
 specific techniques available to each approach. 
 
 This is not a detailed 'how to' guide or set of specific recommendations. The 
@@ -34,7 +34,7 @@ Scaling up: optimising on one machine
 -------------------------------------
 
 Processing speed and capacity will generally increase in line with increases 
-in computing resources (CPU, memory & disk space). When a deployment uses a 
+in computing resources (CPU, memory and disk space). When a deployment uses a 
 machine with considerably more (or less) resources than the 
 :ref:`recommended minimum production requirements <requirements-production>`, 
 there are several different configuration options that may help further 
@@ -243,7 +243,7 @@ less impact on performance when distributed to remote storage locations.
 Process configuration strategies 
 --------------------------------
 
-Optimising what & how preservation actions get executed
+Optimising what and how preservation actions get executed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The final strategy for improving the performance and capacity of your 
@@ -251,7 +251,7 @@ Archivematica deployment is to ensure that Archivematica is only carrying out
 the work you deem important and necessary. Archivematica provides a wide 
 range of preservation actions and the default settings tend to make use of the 
 majority of them. There are several techniques for limiting which actions are 
-taken, that can have a significant impact on the overall time & compute 
+taken, that can have a significant impact on the overall time and compute 
 required to process a particular Transfer or SIP. 
 
 Environment configuration options

--- a/admin-manual/installation-setup/customization/scaling-archivematica.rst
+++ b/admin-manual/installation-setup/customization/scaling-archivematica.rst
@@ -10,15 +10,15 @@ Overview
 --------
 
 Archivematica includes a number of features and options to improve scalability
-& performance. The default configuration options are geared towards “typical” 
-use cases and for many users won’t require any modification. However, some 
+& performance. The default configuration options are geared towards "typical" 
+use cases and for many users won't require any modification. However, some 
 users will benefit from optimizing configuration options to meet their 
 specific preservation needs & available computing resources.
 
 This guide describes three broad approaches to scaling & optimization and the 
 specific techniques available to each approach. 
 
-This is not a detailed ‘how to’ guide or set of specific recommendations. The 
+This is not a detailed 'how to' guide or set of specific recommendations. The 
 goal here is to explain what broad strategies are available and enough of the 
 implementation details to allow skilled administrators to choose and implement 
 the right strategy for their institution. 
@@ -203,20 +203,20 @@ Adjusting timeouts
 ++++++++++++++++++
 
 Timeout settings are an important tool to mitigate failure scenarios created 
-when one component can’t connect to another. The challenge is to set timeouts 
+when one component can't connect to another. The challenge is to set timeouts 
 so that they are long enough to allow particular processes to complete, but 
-not so long that system resources are left idle (or user’s time is wasted), 
-waiting for a response from another component that has failed or can’t be 
+not so long that system resources are left idle (or user's time is wasted), 
+waiting for a response from another component that has failed or can't be 
 reached due to network connectivity issues.  
 
 The standard timeout parameters for each component are used for long-running 
-(generally asynchronous) processes. “Quick” timeout values are for processes 
+(generally asynchronous) processes. "Quick" timeout values are for processes 
 that are synchronous and short (for instance, when an API is called to return 
 information to the UI for a waiting user). 
 
-The default value for the “Quick” timeouts is 120 seconds. This is optimal for 
-components that are located on the same machine, and will be adequate in many 
-cases for components that are distributed to machines that are co-located. 
+The default value for the "Quick" timeouts is optimal for components that are 
+located on the same machine, and will be adequate in many cases for components 
+that are distributed to machines that are co-located. 
 
 There may be times when timeout values should be increased for distributed 
 components that are not co-located, or are slower due to the nature of the 
@@ -234,7 +234,7 @@ The Storage Service Administrator manual describes the different types of
 
 In many cases it may be necessary to use different machines for different types
 of storage locations. In general, we recommend having the most frequently used 
-locations (e.g. the “currently processing” location) on a local machine. 
+locations (e.g. the "currently processing" location) on a local machine. 
 Locations that are used less frequently, such as AIP or DIP storage, will have 
 less impact on performance when distributed to remote storage locations.  
 
@@ -289,14 +289,14 @@ Allow indexing to fail
 
 Indexing very large datasets can be so resource-intensive that indexing will 
 fail. By default, Archivematica will abort processing and invoked the 
-“Failed SIP” microservice. 
+"Failed SIP" microservice. 
 
 The ``ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_INDEX_AIP_CONTINUE_ON_ERROR`` parameter 
 can be set to allow indexing to fail. When this is set and indexing fails, 
-the AIP will carry on with processing and be stored. It can’t be found using 
+the AIP will carry on with processing and be stored. It can't be found using 
 the normal search features in the Appraisal and Archival Storage tabs. 
 
-This feature doesn’t optimize performance so much as mitigate performance 
+This feature doesn't optimize performance so much as mitigate performance 
 limitations. See `MCPClient`_ Configuration for details. 
 
 Disabling task output
@@ -331,7 +331,8 @@ should be adequate and will save processing time.
 without defaults` will only generate thumbnail images for formats that have a 
 specific thumbnail rule defined. The default thumbnail rule only produces a 
 grey icon and for many formats has little value, but in transfers with many 
-files, can take significant processing time. 
+files, can take significant processing time. It is also possible to disable
+generation of thumbnails entirely by selecting  `no`.  
 
 **Select compression algorithm:** AIP compression causes an AIP to be put into 
 a container (e.g. a 7Zip container).  Using containers makes AIP storage and 
@@ -363,12 +364,12 @@ files, or binary files created by instruments in scientific experiments, the
 output can be verbose without being useful. 
 
 **Reduce number of image characterization rules:** Archivematica has rules 
-defined for all image formats to use ExifTool, Mediainfo and ffprobe for 
-characterisation. Using multiple tools ensures as much characterization output 
-as possible, but also introduces some level of duplication. Only using one of 
-the three tools for certain formats may provide an adequate level of 
-characterization with the benefit of reducing processing time and the size of 
-the final AIP. 
+defined for all image and audio-visual formats to use ExifTool, Mediainfo and 
+ffprobe for characterisation. Using multiple tools ensures as much 
+characterization output as possible, but also introduces some level of 
+duplication. Only using one of the three tools for certain formats may provide 
+an adequate level of characterization with the benefit of reducing processing 
+time and the size of the final AIP. 
 
 See :ref:`Characterization <characterization>` and 
 :ref:`Altering commands and rules <altering-commands-rules>` for more details.  
@@ -379,8 +380,8 @@ General Configuration Settings
 **Checksum Algorithm:** In the :ref:`General settings <dashboard-general>` 
 screen you can select which checksum algorithm Archivematica will use during 
 the Assign UUIDs and checksums micro-service. For the purposes of fixity 
-checking, the MD5 algorithm is perfectly adequate and takes less processing 
-time to create (and check) than the alternatives (e.g. SHA-256). 
+checking, the MD5 algorithm may be adequate and takes less processing time 
+to create (and check) than the alternatives (e.g. SHA-256). 
 
 :ref:`Back to the top <scaling-archivematica>`
 

--- a/admin-manual/installation-setup/customization/scaling-archivematica.rst
+++ b/admin-manual/installation-setup/customization/scaling-archivematica.rst
@@ -244,7 +244,7 @@ Process configuration strategies
 --------------------------------
 
 Optimising what and how preservation actions get executed
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The final strategy for improving the performance and capacity of your 
 Archivematica deployment is to ensure that Archivematica is only carrying out 

--- a/admin-manual/installation-setup/installation/_csv/.~lock.install-landing.csv#
+++ b/admin-manual/installation-setup/installation/_csv/.~lock.install-landing.csv#
@@ -1,1 +1,0 @@
-,emescey,msc.lan,05.10.2018 13:34,file:///Users/emescey/Library/Application%20Support/LibreOffice/4;

--- a/admin-manual/installation-setup/installation/_csv/.~lock.install-landing.csv#
+++ b/admin-manual/installation-setup/installation/_csv/.~lock.install-landing.csv#
@@ -1,0 +1,1 @@
+,emescey,msc.lan,05.10.2018 13:34,file:///Users/emescey/Library/Application%20Support/LibreOffice/4;

--- a/admin-manual/installation-setup/installation/install-advanced.rst
+++ b/admin-manual/installation-setup/installation/install-advanced.rst
@@ -7,7 +7,7 @@ Advanced installation options
 *On this page*
 
 * :ref:`Installing for development <development>`
-* :ref:`Installing across multiple machines <multiple-machines>`
+* :ref:`Scaling Archivematica <installation-scaling>`
 * :ref:`Configuring Archivematica with SSL <SSL-support>`
 
 .. _development:
@@ -25,44 +25,19 @@ instructions on how to install Archivematica from a virtual machine, see the
 also instructions for installation on a virtual machine using Vagrant in the
 :ref:`Quick Start Guide <quick-start-install>`.
 
-.. _multiple-machines:
+.. _installation-scaling:
 
-Installing across multiple machines
------------------------------------
+Scaling Archivematica
+---------------------
 
-It is possible to spread Archivematica's processing load across several machines
-by installing the following services on separate machines:
+There are several approaches to installing and configuring Archivematica 
+to handle large volumes of data and improve system performance. 
 
-* Elasticsearch
-* Gearman
-* MySQL
+The :ref:`Scaling Archivematica <scaling-archivematica>` section includes: 
 
-For help, ask on the `Archivematica user forum`_ for more details.
-
-Firewall
-^^^^^^^^
-
-When installing Archivematica on multiple machines, the various Archivematica
-processes must be able to reach each other on the relevant ports. Your firewall
-configuration must allow for this.
-
-In particular, please ensure that the Archivematica dashboard can talk to the
-Storage Service, and that the pipeline components (i.e., MCPServer, MCPClient)
-can talk to Gearman.
-
-In addition, please ensure that the Elasticsearch (``9200``) and MySQL
-(``3306``) services are not exposed to the world.
-
-The ports of the Archivematica components and related services are provided
-below.
-
-* Archivematica dashboard: ``80`` (``81`` for RPM-based installs)
-* Archivematica Storage Service: ``8000`` (``8001`` for RPM-based installs)
-* MySQL: ``3306``
-* Gearman: ``4730``
-* SSH: ``22``
-* Elasticsearch: ``9200``
-* NFS: ``2049``
+* :ref:`Scaling up: optimising on one machine <scaling-up>` 
+* :ref:`Scaling out: optimising across multiple machines <scaling-out>`
+* :ref:`Process configuration strategies <config-strategies>`
 
 .. _SSL-support:
 
@@ -80,7 +55,6 @@ In order to obtain valid SSL certificates trusted by any browser, you can use
 
 .. _`archivematica-tech`: https://groups.google.com/forum/#!forum/archivematica-tech
 .. _`Archivematica Docker repo`: https://github.com/artefactual-labs/am/tree/master/compose
-.. _`Archivematica user forum`: https://groups.google.com/a/artefactual.com/forum/#!forum/archivematica
 .. _`Ansible & Vagrant installation instructions`: https://wiki.archivematica.org/Getting_started#Installation
 .. _`sample configurations for the dashboard`: https://github.com/artefactual-labs/ansible-archivematica-src/blob/qa/1.7.x/templates/etc/nginx/sites-available/dashboard-ssl.conf.j2
 .. _`sample configurations for the Storage Service`: https://github.com/artefactual-labs/ansible-archivematica-src/blob/qa/1.7.x/templates/etc/nginx/sites-available/storage-ssl.conf.j2

--- a/admin-manual/installation-setup/installation/installation.rst
+++ b/admin-manual/installation-setup/installation/installation.rst
@@ -215,10 +215,9 @@ There are many ways to install Archivematica, depending on the needs of the
 individual user. We have documented some common advanced installation setups.
 
 * :ref:`Installing for development <development>`
-* :ref:`Installing across multiple machines <multiple-machines>`
 * :ref:`Configure Archivematica with SSL <SSL-support>`
 * :ref:`Configure Archivematica with task output capturing disabled <task-output-capturing-admin>`
-
+* :ref:`Scaling Archivematica <scaling-archivematica>` 
 
 :ref:`Back to the top <installation>`
 


### PR DESCRIPTION
This pull request adds a new "Scaling Archivematica" document that describes three broad strategies for installing or configuring Archivematica to support large volumes or optimize processing power. 

New configuration options for MCP Batching are described, connected to #182 

Additional config details for new timeouts added in 1.8 are described (the 'quick' timeouts to support the asynch API changes) connected to https://github.com/artefactual/archivematica/issues/1133

In addition to technical strategies for improving performance, the final section includes configuration options that end users could make to optimize for scale or performance (e.g. changing processing configuration settings or FPR rules). 

@sevein has already reviewed the technical documentation in detail ('scaling up' and 'scaling out') and no major changes have been made there. The final section needs an analyst review for accuracy (i.e. to ensure that I'm not making it sound like we are _recommending_ anything we shouldn't. I've tried to word these as 'options' not recommendations). 
