### PR TITLE
Improve cross-references for AtoM integration

### DIFF
--- a/admin-manual/installation-setup/customization/dashboard-config.rst
+++ b/admin-manual/installation-setup/customization/dashboard-config.rst
@@ -277,6 +277,11 @@ The AtoM/Binder DIP upload configuration page is where you specify the details
 of the AtoM or Binder installation you'd like the DIPs uploaded to (and, if
 using Rsync to transfer the DIP files, Rsync transfer details).
 
+Before setting these details, please ensure that you have a working AtoM or
+Binder site that is properly connected to Archivematica. See :ref:`Using AtoM
+2.x with Archivematica <atom-setup>` or :ref:`Using Binder with Archivematica
+<binder-setup>` for more information.
+
 .. image:: images/AtoMDIPConfig.*
    :align: center
    :width: 80%

--- a/admin-manual/installation-setup/integrations/atom-setup.rst
+++ b/admin-manual/installation-setup/integrations/atom-setup.rst
@@ -5,25 +5,21 @@ Using AtoM 2.x with Archivematica
 =================================
 
 Archivematica |version| has been tested with and is recommended for use with the
-latest version of AtoM. AtoM version 2.2 or higher is required for use with the
-hierarchical DIP functionality; see :ref:`Arrange a SIP from backlog <arrange-sip>`.
-
-Installation instructions for AtoM 2 are available on the
-:ref:`accesstomemory.org documentation <atom:home>`. When following those
-instructions, it is best to download AtoM from the git repository (rather than
-use one of the supplied tarballs).
+latest version of AtoM. AtoM version 2.2 or higher is required if you wish to
+use the :ref:`hierarchical DIP functionality <hierarchical-dip>`.
 
 *On this page*
 
 * :ref:`Install AtoM <install-atom>`
 * :ref:`Configure DIP upload <config-dip-upload>`
+* :ref:`User instructions <user-instructions-atom>`
 
 .. _install-atom:
 
 Install AtoM
 ------------
 
-Installation instructions for AtoM 2 are available on the
+Installation instructions for AtoM 2 are available in the
 :ref:`accesstomemory.org documentation <atom:home>`. When following those
 instructions, it is best to download AtoM from the git repository (rather than
 use one of the supplied tarballs).
@@ -33,25 +29,33 @@ use one of the supplied tarballs).
 Configure DIP upload
 --------------------
 
-Once you have a working AtoM installation, you can configure DIP upload
-between Archivematica and AtoM. The basic steps are:
+Once you have a working AtoM installation, enter the appropriate credentials and
+information on the Administration tab. See :ref:`AtoM/Binder DIP upload
+<admin-dashboard-atom>` for more information.
 
-* Update AtoM DIP upload configuration in the Archivematica dashboard
+Once this is complete, there are
 
-* Confirm atom-worker is configured on the AtoM server (copy the atom-
-  worker.conf file from AtoM source to /etc/init/)
+#. Confirm atom-worker is configured on the AtoM server (copy the ``atom-
+   worker.conf`` file from AtoM source to ``/etc/init/``).
+#. Enable the :ref:`SWORD plugin <atom:manage-plugins>` from the AtoM Plugins
+   menu.
+#. Enable `job scheduling`_ in the AtoM settings page (AtoM version 2.1 or lower
+   only).
+#. Confirm gearman is installed on the AtoM server.
+#. Configure SSH keys to allow rsync to work for the Archivematica user, from
+   the Archivematica server to the AtoM server.
+#. Restart gearman on the AtoM server.
+#. Restart the AtoM worker on the AtoM server.
 
-* Enable the Sword Plugin in the AtoM plugins page
+.. _user-instructions-atom:
 
-* Enable job scheduling in the AtoM settings page (AtoM version 2.1 or lower only)
+User instructions
+-----------------
 
-* Confirm gearman is installed on the AtoM server
-
-* Configure ssh keys to allow rsync to work for the archivematica user, from
-  the Archivematica server to the AtoM server
-
-* Start gearman on the AtoM server
-
-* Start the AtoM worker on the AtoM server
+Instructions on how to upload a DIP to AtoM can be found in the User Manual
+section :ref:`Upload a DIP to AtoM <upload-atom>`.
 
 :ref:`Back to the top <atom-setup>`
+
+
+.. _job scheduling: https://www.accesstomemory.org/en/docs/2.1/user-manual/administer/settings/#job-scheduling

--- a/user-manual/access/access.rst
+++ b/user-manual/access/access.rst
@@ -59,9 +59,10 @@ environment. Access integration workflows also exist for `ArchivesSpace`_,
 Upload a DIP to AtoM
 --------------------
 
-To upload DIPs to your AtoM instance, you must enter your AtoM information and
-credentials in the Administration tab. See :ref:`AtoM/Binder DIP upload
-<admin-dashboard-atom>` for more information.
+To upload DIPs to AtoM, you must first have a working AtoM instance. An
+administrator will need to configure the AtoM instance to talk to Archivematica.
+For more information about setting up an integration with AtoM, see :ref:`Using
+AtoM 2.x with Archivematica <atom-setup>`.
 
 .. important::
 


### PR DESCRIPTION
This change improves cross-references for information about setting up an AtoM
integration. Thinking of the admin-manual/integrations/atom-setup page as a
landing page for all integrations-related material, I've added clearer links to
other places that configuration information exists (i.e. the dashboard config
pages) as well as links to user documentation. Conversely, I've also added
reinforced wording on user-oriented pages that point to the integrations page
as the place to get started if you're setting up a new integration.

Connected to archivematica/Issues#293