### PR TITLE
Update Elasticsearch installation options

### DIFF
--- a/admin-manual/installation-setup/installation/install-centos.rst
+++ b/admin-manual/installation-setup/installation/install-centos.rst
@@ -51,8 +51,8 @@ Installation instructions
    * Elasticsearch (optional):
 
    .. note::
-      Skip this step if you are planning to run Archivematica in
-      indexless mode (without Elasticsearch).
+      Skip this step if you are planning to run :ref:`Archivematica without
+      Elasticsearch <install-elasticsearch>`.
 
    .. code:: bash
 

--- a/admin-manual/installation-setup/installation/install-ubuntu.rst
+++ b/admin-manual/installation-setup/installation/install-ubuntu.rst
@@ -37,8 +37,9 @@ Ubuntu 16.04 (Xenial) installation instructions
 2. Add Elasticsearch package source (optional). Elasticsearch comes from its own
    package repository.
 
-   .. note:: Skip this step if you are planning to run Archivematica in indexless
-      mode (without Elasticsearch).
+   .. note::
+      Skip this step if you are planning to run :ref:`Archivematica without
+      Elasticsearch <install-elasticsearch>`.
 
    .. code:: bash
 

--- a/admin-manual/installation-setup/installation/installation.rst
+++ b/admin-manual/installation-setup/installation/installation.rst
@@ -91,15 +91,31 @@ information, see :ref:`Advanced <advanced>`.
 Elasticsearch
 ^^^^^^^^^^^^^
 
-Installing Elasticsearch to provide a search index is now optional as of
-Archivematica version 1.7. Installing Archivematica without Elasticsearch means
-reduced consumption of compute resources and lower operational complexity.
-However, some functionality, such as the Backlog, Appraisal and Archival Storage
-tabs, is not available.
+Installing Elasticsearch with a search index is optional as of Archivematica
+1.7. Installing Archivematica without Elasticsearch, or with limited
+Elasticsearch functionality, means reduced consumption of compute resources and
+lower operational complexity. By setting the
+``archivematica_src_search_enabled`` configuration attribute, administrators can
+define how many things Elasticsearch is indexing, if any. This can impact
+searching across several different dashboard pages.
+
+Possible ``archivematica_src_search_enabled`` configuration attribute values:
+
+* ``transfers``: Only transfers are indexed. Search is enabled on the Backlog
+  and Appraisal tabs, but not the Archival Storage tab.
+* ``aips``: Only AIPs are indexed. Search is enabled on the Archival Storage
+  tab, but not the Backlog or Appraisal tabs.
+* ``aips,transfers``, or ``true``: Both AIPs and transfers are indexed.
+  Search works on the Backlog, Appraisal, and Archival Storage tabs.
+* ``false``: Indexless mode. Neither AIPs nor transfers are indexed. The
+  Backlog, Appraisal, and Archival Storage tabs will be non-functional.
 
 When Elasticsearch is used, Archivematica |release| requires version 1.x (tested
 with 1.7.6). Support for a more recent version of Elasticsearch is being
 developed and is planned for a future release.
+
+For more information on disabling Elasticsearch, please see the README for
+Archivematica's ansible role,
 
 Hardware
 ^^^^^^^^

--- a/admin-manual/installation-setup/upgrading/upgrading.rst
+++ b/admin-manual/installation-setup/upgrading/upgrading.rst
@@ -298,10 +298,12 @@ Upgrade in indexless mode
 -------------------------
 
 As of Archivematica 1.7, Archivematica can be run in indexless mode; that is,
-without Elasticsearch. Installing Archivematica without Elasticsearch means
-reduced consumption of compute resources and lower operational complexity.
-Disabling Elasticsearch means that the Backlog, Appraisal, and Archival Storage
-tabs do not appear and their functionality is not available.
+without Elasticsearch. Installing Archivematica without Elasticsearch, or with
+limited Elasticsearch functionality, means reduced consumption of compute
+resources and lower operational complexity. By setting the
+``archivematica_src_search_enabled`` configuration attribute, administrators can
+define how many things Elasticsearch is indexing, if any. This can impact
+searching across several different dashboard pages.
 
 1. Upgrade your existing Archivematica pipeline following the instructions
    above.

--- a/user-manual/appraisal/appraisal.rst
+++ b/user-manual/appraisal/appraisal.rst
@@ -14,8 +14,9 @@ found in previous versions of Archivematica, also has moved to the Appraisal tab
 
 .. note::
 
-   If you are running Archivematica in indexless mode (without Elasticsearch),
-   the Appraisal tab will not appear on your dashboard.
+   If you are running :ref:`Archivematica without Elasticsearch
+   <install-elasticsearch>` or with limited Elasticsearch functionality, the
+   Appraisal tab will not appear in your dashboard.
 
 *On this page:*
 
@@ -216,8 +217,8 @@ by the parallel lines icon.
 
 .. note::
 
-   Digital objects created and linked to resources in ArchivesSpace will 
-   not appear in the ArchivesSpace panel. However, digital objects added 
+   Digital objects created and linked to resources in ArchivesSpace will
+   not appear in the ArchivesSpace panel. However, digital objects added
    to a resource from within the ArchivesSpace panel are displayed.
 
 .. image:: images/archivesspace_search.*
@@ -232,7 +233,7 @@ Options at the top of the ArchivesSpace pane allow for adding to and changing an
 existing ArchivesSpace resource, such as adding new archival objects and digital
 object components.
 
-Selecting a resource or archival object and using “Add new child record” adds 
+Selecting a resource or archival object and using “Add new child record” adds
 a new archival object nested underneath the selected level of description.
 Clicking this button brings up a dialog box for entering metadata. At a minimum,
 a new archival object must have a title and a level of description, otherwise
@@ -308,15 +309,15 @@ Transfer files in backlog can easily be associated with ArchivesSpace resources 
 To add files to ArchivesSpace resources:
 
 1. Search the backlog by entering terms and parameters in the search box at the top of the page.
-   
+
    For a list of all transfers in backlog, simply click within the search box leaving the edit field blank, and then click **Search transfer backlog**.
 
 2. Click **ArchivesSpace** to enable the ArchivesSpace panel, :ref:`search by title or identifier of a resource <searching-ArchivesSpace-resources>`, and then click **Search ArchivesSpace**.
-   
+
    A hierarchical view of the resource is displayed.
-   
-3. Create digital object components within the ArchivesSpace panel by clicking **Add new digital object**.   
-   
+
+3. Create digital object components within the ArchivesSpace panel by clicking **Add new digital object**.
+
    Digital object components must be created in the Appraisal tab.
 
 .. note::

--- a/user-manual/archival-storage/archival-storage.rst
+++ b/user-manual/archival-storage/archival-storage.rst
@@ -11,8 +11,9 @@ Should you run into an error during archival storage, please see
 
 .. note::
 
-   If you are running Archivematica in indexless mode (without Elasticsearch),
-   the Archival Storage tab will not appear on your dashboard.
+   If you are running :ref:`Archivematica without Elasticsearch
+   <install-elasticsearch>` or with limited Elasticsearch functionality, the
+   Archival Storage tab will not appear in your dashboard.
 
 *On this page*
 

--- a/user-manual/backlog/backlog.rst
+++ b/user-manual/backlog/backlog.rst
@@ -14,8 +14,9 @@ backlogged material in a new Archivematica pipeline.
 
 .. note::
 
-  If you are running Archivematica in indexless mode (without Elasticsearch),
-  the Appraisal tab will not appear on your dashboard.
+   If you are running :ref:`Archivematica without Elasticsearch
+   <install-elasticsearch>` or with limited Elasticsearch functionality, the
+   Backlog tab will not appear in your dashboard.
 
 *On this page:*
 


### PR DESCRIPTION
There are 4 possible configurations for Elasticsearch in Archivematica 1.8.
This change lists them and updates the information on related pages.

Connected to artefactual/archivematica#1172

@jraddaoui Is there anything that needs to be updated in the installation documentation to address this? I added the attribute variable info to the main installation page, but didn't change anything (except adding a link) to the install pages themselves. Also the upgrading page.