### PR TITLE
Ubuntu: Use systemctl to enable elasticsearch

### DIFF
--- a/admin-manual/installation-setup/installation/install-ubuntu.rst
+++ b/admin-manual/installation-setup/installation/install-ubuntu.rst
@@ -188,7 +188,7 @@ Ubuntu 16.04 (Xenial) and Ubuntu 18.04 (Bionic) installation instructions
     .. code:: bash
 
        sudo service elasticsearch restart
-       sudo update-rc.d elasticsearch defaults 95 10
+       sudo systemctl enable elasticsearch
 
 12. Start the remaining services
 


### PR DESCRIPTION
The old SystemV command is being used to enable the ElasticSearch
service. It is more appropriate to use the systemd command to enable the
service.

Connects to https://github.com/archivematica/Issues/issues/316