### PR TITLE
Refine instructions associated with downloading and installing devtools

### DIFF
--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -407,8 +407,10 @@ an alternative to using the dashboard.
    more information about installation methods, please see :ref:`installation`.
 
 1. Clone the `archivematica-devtools`_ repository into your Archivematica source
+   repository and follow the installation instructions found within the 
    repository. On Ubuntu or CentOS, clone the repository to
-   `/opt/archivematica`. On vagrant, clone the repository to `/vagrant/src/`.
+   `/opt/archivematica`. On vagrant, clone the repository to `/vagrant/src/`. 
+   You should be able to access the devtools by running the `am` command.
 
 2. Navigate to the Archivematica MCP Client directory and start the mcp-rpc-cli.
 


### PR DESCRIPTION
I hadn't used these, so I didn't realize that the devtools were more than just scripts that I could run, and installation isn't as intuitive as expected.

I also don't think navigating to the MCP Client folder is necessary, but since I wasn't sure, I left it as it is.