### PR TITLE
Fixed documentation typo for REQUESTS_CA_BUNDLE.

### DIFF
--- a/admin-manual/security/security.rst
+++ b/admin-manual/security/security.rst
@@ -197,7 +197,7 @@ using systemd:
    $ sudo systemctl restart archivematica-storage-service
 
 Use the environment string REQUESTS_CA_BUNDLE
-++++++++++++++++++++++++++++++++++++++++++++
++++++++++++++++++++++++++++++++++++++++++++++
 
 Requests honours the environment string ``REQUESTS_CA_BUNDLE`` so the
 administrator can indicate a custom bundle which could be the system's CA

--- a/admin-manual/security/security.rst
+++ b/admin-manual/security/security.rst
@@ -196,10 +196,10 @@ using systemd:
    $ sudo systemctl restart archivematica-mcp-client
    $ sudo systemctl restart archivematica-storage-service
 
-Use the environment string REQUEST_CA_BUNDLE
+Use the environment string REQUESTS_CA_BUNDLE
 ++++++++++++++++++++++++++++++++++++++++++++
 
-Requests honours the environment string ``REQUEST_CA_BUNDLE`` so the
+Requests honours the environment string ``REQUESTS_CA_BUNDLE`` so the
 administrator can indicate a custom bundle which could be the system's CA
 bundle.
 
@@ -213,19 +213,19 @@ files to use the system's CA bundle:
 
 .. code:: bash
 
-   REQUEST_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+   REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
 On CentOS, add the following line to the :file:`/etc/default/archivematica-*`
 files to use the system's CA bundle:
 
 .. code:: bash
 
-   REQUEST_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+   REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 
 Trusting additional CAs
 +++++++++++++++++++++++
 
-If you are using ``REQUEST_CA_BUNDLE`` you may want to trust additional CAs.
+If you are using ``REQUESTS_CA_BUNDLE`` you may want to trust additional CAs.
 
 On CentOS:
 

--- a/locale/es/LC_MESSAGES/admin-manual/security/security.po
+++ b/locale/es/LC_MESSAGES/admin-manual/security/security.po
@@ -273,12 +273,12 @@ msgid ""
 msgstr ""
 
 #: ../../admin-manual/security/security.rst:200
-msgid "Use the environment string REQUEST_CA_BUNDLE"
+msgid "Use the environment string REQUESTS_CA_BUNDLE"
 msgstr ""
 
 #: ../../admin-manual/security/security.rst:202
 msgid ""
-"Requests honours the environment string ``REQUEST_CA_BUNDLE`` so the "
+"Requests honours the environment string ``REQUESTS_CA_BUNDLE`` so the "
 "administrator can indicate a custom bundle which could be the system's CA"
 " bundle."
 msgstr ""
@@ -313,7 +313,7 @@ msgstr ""
 
 #: ../../admin-manual/security/security.rst:228
 msgid ""
-"If you are using ``REQUEST_CA_BUNDLE`` you may want to trust additional "
+"If you are using ``REQUESTS_CA_BUNDLE`` you may want to trust additional "
 "CAs."
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/admin-manual/security/security.po
+++ b/locale/fr/LC_MESSAGES/admin-manual/security/security.po
@@ -280,12 +280,12 @@ msgid ""
 msgstr ""
 
 #: ../../admin-manual/security/security.rst:200
-msgid "Use the environment string REQUEST_CA_BUNDLE"
+msgid "Use the environment string REQUESTS_CA_BUNDLE"
 msgstr ""
 
 #: ../../admin-manual/security/security.rst:202
 msgid ""
-"Requests honours the environment string ``REQUEST_CA_BUNDLE`` so the "
+"Requests honours the environment string ``REQUESTS_CA_BUNDLE`` so the "
 "administrator can indicate a custom bundle which could be the system's CA "
 "bundle."
 msgstr ""
@@ -320,7 +320,7 @@ msgstr ""
 
 #: ../../admin-manual/security/security.rst:228
 msgid ""
-"If you are using ``REQUEST_CA_BUNDLE`` you may want to trust additional CAs."
+"If you are using ``REQUESTS_CA_BUNDLE`` you may want to trust additional CAs."
 msgstr ""
 
 #: ../../admin-manual/security/security.rst:230

--- a/locale/pt_BR/LC_MESSAGES/admin-manual/security/security.po
+++ b/locale/pt_BR/LC_MESSAGES/admin-manual/security/security.po
@@ -345,12 +345,12 @@ msgid ""
 msgstr ""
 
 #: ../../admin-manual/security/security.rst:200
-msgid "Use the environment string REQUEST_CA_BUNDLE"
+msgid "Use the environment string REQUESTS_CA_BUNDLE"
 msgstr ""
 
 #: ../../admin-manual/security/security.rst:202
 msgid ""
-"Requests honours the environment string ``REQUEST_CA_BUNDLE`` so the "
+"Requests honours the environment string ``REQUESTS_CA_BUNDLE`` so the "
 "administrator can indicate a custom bundle which could be the system's CA "
 "bundle."
 msgstr ""
@@ -385,7 +385,7 @@ msgstr ""
 
 #: ../../admin-manual/security/security.rst:228
 msgid ""
-"If you are using ``REQUEST_CA_BUNDLE`` you may want to trust additional CAs."
+"If you are using ``REQUESTS_CA_BUNDLE`` you may want to trust additional CAs."
 msgstr ""
 
 #: ../../admin-manual/security/security.rst:230


### PR DESCRIPTION
This is a PR to fix (partially) archivematica/Issues#432