### PR TITLE
Update AtoM integrations setup page

### DIFF
--- a/admin-manual/installation-setup/integrations/atom-setup.rst
+++ b/admin-manual/installation-setup/integrations/atom-setup.rst
@@ -24,24 +24,31 @@ Installation instructions for AtoM 2 are available in the
 instructions, it is best to download AtoM from the git repository (rather than
 use one of the supplied tarballs).
 
+You must enable the SWORD plugin (``qtSwordPlugin``) and the REST API
+(``arRestApiPlugin``) from the:ref:` AtoM plugins menu <atom:manage-plugins>`.
+
 .. _config-dip-upload:
 
 Configure DIP upload
 --------------------
 
 Once you have a working AtoM installation, enter the appropriate credentials and
-information on the Administration tab. See :ref:`AtoM/Binder DIP upload
-<admin-dashboard-atom>` for more information.
+information on Archivematica's Administration tab. See :ref:`AtoM/Binder DIP
+upload <admin-dashboard-atom>` for more information about the fields and their
+values.
 
-Once this is complete, there are
+Next, configure the connection between the two systems:
 
-#. Confirm atom-worker is configured on the AtoM server (copy the ``atom-
-   worker.conf`` file from AtoM source to ``/etc/init/``).
-#. Enable the :ref:`SWORD plugin <atom:manage-plugins>` from the AtoM Plugins
-   menu.
-#. Enable `job scheduling`_ in the AtoM settings page (AtoM version 2.1 or lower
-   only).
-#. Confirm gearman is installed on the AtoM server.
+#. Confirm atom-worker is configured on the AtoM server by copying the ``atom-
+   worker.conf`` file from AtoM source to ``/etc/init/``.
+#. Make sure that the SWORD plugin and AtoM REST API are enabled on the
+   :ref:`AtoM plugins menu <atom:manage-plugins>`.
+
+   a. If you are running AtoM 2.1 or lower, enable `job scheduling`_ in the AtoM
+      settings page. In later versions of AtoM, this is enabled by default.
+
+#. Confirm that gearman is installed on the AtoM server, as per the :ref:`AtoM
+   installation documentation <atom:installation>`.
 #. Configure SSH keys to allow rsync to work for the Archivematica user, from
    the Archivematica server to the AtoM server.
 #. Restart gearman on the AtoM server.


### PR DESCRIPTION
This change adds a note that the AtoM REST API must be enabled from the AtoM
plugins menu during setup. This change also tidies up the integration page and
adds a few more links.

Change will be cherry-picked to 1.9 docs once approved.

Connected to archivematica/Issues#487