### PR TITLE
Fixes links to installation docs

### DIFF
--- a/admin-manual/installation-setup/installation/_csv/install-development.csv
+++ b/admin-manual/installation-setup/installation/_csv/install-development.csv
@@ -1,0 +1,4 @@
+Development environments,,
+"Docker and Linux
+",`Installing Archivematica Using Docker Compose on Linux <https://github.com/artefactual-labs/am/tree/master/compose#docker-and-linux>`_,Docker will provide instructions on how to use it as a non-root user. This may not be desirable for all.
+Docker and Mac,`Installing Archivematica Using Docker Compose on Mac <https://github.com/artefactual-labs/am/tree/master/compose#docker-and-mac>`_ ,Installation of Archivematica on machines running macOS using Docker is possible but still in development and may require some extra steps.

--- a/admin-manual/installation-setup/installation/_csv/install-landing.csv
+++ b/admin-manual/installation-setup/installation/_csv/install-landing.csv
@@ -1,6 +1,6 @@
 Intended use,Environment,Related documents,Notes
 Test-driving the latest release,Archivematica sandbox,:ref:`Using the sandbox <using-the-sandbox>`,"The sandbox will automatically reset daily. Any packages created will not be permanently saved. Additionally, there may be more than one demo user logged in at the same time, so you may see changes made by others while using the software."
-,Local virtual machine using Vagrant and VirtualBox,:ref:`Installing on a virtual machine using Vagrant <installing-on-vm>`,This virtual machine is not intended to be used in production.
+Test-driving the latest release,Local virtual machine using Vagrant and VirtualBox,:ref:`Installing on a virtual machine using Vagrant <installing-on-vm>`,This virtual machine is not intended to be used in production.
 New installations – Production deployment,Ubuntu 16.04 64-bit Server Edition,:ref:`Automated install using Ansible \> Ubuntu 16.04 \(Xenial\)<ubuntu-16.04>`,"These instructions will not work if you are using a Windows machine as the host environment. For Windows installations, see the :ref:`manual install instructions <install-pkg-ubuntu>` for production."
 ,Ubuntu 18.04 64-bit Server Edition,:ref:`Automated install using Ansible \> Ubuntu 18.04 \(Bionic\)<ubuntu-18.04>`,"These instructions will not work if you are using a Windows machine as the host environment. For Windows installations, see the :ref:`manual install instructions <install-pkg-ubuntu>` for production."
 ,CentOS 7 64-bit,:ref:`Installing Archivematica on CentOS/Red Hat<install-pkg-centos>`,Archivematica versions 1.5.1 and higher support installation on CentOS/Red Hat.
@@ -9,3 +9,21 @@ Development,"Docker and Linux
 ",`Installing Archivematica Using Docker Compose on Linux <https://github.com/artefactual-labs/am/tree/master/compose#docker-and-linux>`_,Docker will provide instructions on how to use it as a non-root user. This may not be desirable for all.
 ,Docker and Mac,`Installing Archivematica Using Docker Compose on Mac <https://github.com/artefactual-labs/am/tree/master/compose#docker-and-mac>`_ ,Installation of Archivematica on machines running macOS using Docker is possible but still in development and may require some extra steps.
 Spreading Archivematica’s processing load across several machines,Base on your customized setup and network configuration,:ref:`Scaling Archivematica<scaling-archivematica>`,"When installing Archivematica on multiple machines, the various Archivematica processes must be able to reach each other on the relevant ports. Your firewall configuration must allow for this."
+,,,
+,,,
+,,,
+,,,
+Test-driving the latest release,,,
+Archivematica sandbox,:ref:`Using the sandbox <using-the-sandbox>`,"The sandbox will automatically reset daily. Any packages created will not be permanently saved. Additionally, there may be more than one demo user logged in at the same time, so you may see changes made by others while using the software.",
+Local virtual machine using Vagrant and VirtualBox,:ref:`Installing on a virtual machine using Vagrant <installing-on-vm>`,This virtual machine is not intended to be used in production.,
+New installations – Production deployment,,,
+Ubuntu 16.04 64-bit Server Edition,:ref:`Automated install using Ansible \> Ubuntu 16.04 \(Xenial\)<ubuntu-16.04>`,"These instructions will not work if you are using a Windows machine as the host environment. For Windows installations, see the :ref:`manual install instructions <install-pkg-ubuntu>` for production.",
+Ubuntu 18.04 64-bit Server Edition,:ref:`Automated install using Ansible \> Ubuntu 18.04 \(Bionic\)<ubuntu-18.04>`,"These instructions will not work if you are using a Windows machine as the host environment. For Windows installations, see the :ref:`manual install instructions <install-pkg-ubuntu>` for production.",
+CentOS 7 64-bit,:ref:`Installing Archivematica on CentOS/Red Hat<install-pkg-centos>`,Archivematica versions 1.5.1 and higher support installation on CentOS/Red Hat.,
+Windows OS,Not supported,,
+Development,,,
+"Docker and Linux
+",`Installing Archivematica Using Docker Compose on Linux <https://github.com/artefactual-labs/am/tree/master/compose#docker-and-linux>`_,Docker will provide instructions on how to use it as a non-root user. This may not be desirable for all.,
+Docker and Mac,`Installing Archivematica Using Docker Compose on Mac <https://github.com/artefactual-labs/am/tree/master/compose#docker-and-mac>`_ ,Installation of Archivematica on machines running macOS using Docker is possible but still in development and may require some extra steps.,
+Spreading Archivematica’s processing load across several machines,,,
+Base on your customized setup and network configuration,:ref:`Scaling Archivematica<scaling-archivematica>`,"When installing Archivematica on multiple machines, the various Archivematica processes must be able to reach each other on the relevant ports. Your firewall configuration must allow for this.",

--- a/admin-manual/installation-setup/installation/_csv/install-multiple-machines.csv
+++ b/admin-manual/installation-setup/installation/_csv/install-multiple-machines.csv
@@ -1,0 +1,2 @@
+Spreading Archivematica’s processing load across several machines,,
+Base on your customized setup and network configuration,:ref:`Scaling Archivematica<scaling-archivematica>`,"When installing Archivematica on multiple machines, the various Archivematica processes must be able to reach each other on the relevant ports. Your firewall configuration must allow for this."

--- a/admin-manual/installation-setup/installation/_csv/install-new.csv
+++ b/admin-manual/installation-setup/installation/_csv/install-new.csv
@@ -1,0 +1,5 @@
+New installations for production deployment,,
+Ubuntu 16.04 64-bit Server Edition,:ref:`Automated install using Ansible \> Ubuntu 16.04 \(Xenial\)<install-ansible>`,"These instructions will not work if you are using a Windows machine as the host environment. For Windows installations, see the :ref:`manual install instructions <install-pkg-ubuntu>` for production."
+Ubuntu 18.04 64-bit Server Edition,:ref:`Automated install using Ansible \> Ubuntu 18.04 \(Bionic\)<install-ansible>`,"These instructions will not work if you are using a Windows machine as the host environment. For Windows installations, see the :ref:`manual install instructions <install-pkg-ubuntu>` for production."
+CentOS 7 64-bit,:ref:`Installing Archivematica on CentOS/Red Hat<install-pkg-centos>`,Archivematica versions 1.5.1 and higher support installation on CentOS/Red Hat.
+Windows OS,Not supported,

--- a/admin-manual/installation-setup/installation/_csv/install-testing.csv
+++ b/admin-manual/installation-setup/installation/_csv/install-testing.csv
@@ -1,0 +1,3 @@
+Test-driving the latest release,,
+Archivematica sandbox,:ref:`Using the sandbox <using-the-sandbox>`,"The sandbox will automatically reset daily. Any packages created will not be permanently saved. Additionally, there may be more than one demo user logged in at the same time, so you may see changes made by others while using the software."
+Local virtual machine using Vagrant and VirtualBox,:ref:`Installing on a virtual machine using Vagrant <installing-on-vm>`,This virtual machine is not intended to be used in production.

--- a/admin-manual/installation-setup/installation/install-ansible.rst
+++ b/admin-manual/installation-setup/installation/install-ansible.rst
@@ -9,9 +9,7 @@ installations on Ubuntu.
 
 It is assumed here that your host operating system is Ubuntu. This can be
 modified for a different Unix based operating system, such as Mac OS X or
-another Linux distribution such as CentOS. These instructions will not
-work if you are using Windows as the host OS. For Windows installations
-you can create a virtual machine and follow the manual install instructions.
+another Linux distribution such as CentOS.
 
 The Ansible roles referenced here can be used in production deployments
 by creating your own Ansible playbook to run them. See the `deploy-pub`_ repo

--- a/admin-manual/installation-setup/installation/installation.rst
+++ b/admin-manual/installation-setup/installation/installation.rst
@@ -16,8 +16,7 @@ Installing Archivematica
 Overview
 --------
 
-The following table lists all help topics on installing Archivematica for
-various intended uses and host environments. Further down the page, you will
+The following table lists various ways to install and use Archivematica. Further down the page, you will
 find more detailed information about new installations and advanced installation
 options.
 
@@ -25,7 +24,19 @@ If you need assistance or clarification regarding the installation instructions,
 the `Archivematica user forum`_ is a good place ask questions.
 
 .. csv-table::
-   :file: _csv/install-landing.csv
+   :file: _csv/install-new.csv
+   :header-rows: 1
+
+.. csv-table::
+   :file: _csv/install-testing.csv
+   :header-rows: 1
+
+.. csv-table::
+   :file: _csv/install-development.csv
+   :header-rows: 1
+
+.. csv-table::
+   :file: _csv/install-multiple-machines.csv
    :header-rows: 1
 
 .. _treq:
@@ -189,8 +200,8 @@ supported installation environments:
   <install-ansible>`.
 * :ref:`Manual install of OS packages on CentOS/Red Hat <install-pkg-centos>`
 
-:ref:`Manual install of OS packages on Ubuntu (16.04 and 18.04) <install-pkg-ubuntu>`
-is documented but not officially supported.
+Note that :ref:`manual install of OS packages on Ubuntu (16.04 and 18.04)
+<install-pkg-ubuntu>` is documented but not officially supported.
 
 Installing Archivematica using :ref:`Docker <development>` is not officially
 supported for production deployments. However, it is the preferred development

--- a/user-manual/archival-storage/archival-storage.rst
+++ b/user-manual/archival-storage/archival-storage.rst
@@ -1,4 +1,4 @@
-wiki.. _archival-storage:
+.. _archival-storage:
 
 ================
 Archival storage


### PR DESCRIPTION
Some of the links in the table on the installation page were broken,
taking users to the wrong place in the installation docs. I've fixed those
links and also made the tables a little nicer looking by breaking each
section into a separate table. Sphinx's table formatting isn't very advanced
so this was a way to get the headers to look nicer.

Connected to archivematica/issues#661