### PR TITLE
Update forensic.rst for clarity and style

### DIFF
--- a/admin-manual/installation-setup/customization/scaling-archivematica.rst
+++ b/admin-manual/installation-setup/customization/scaling-archivematica.rst
@@ -24,6 +24,7 @@ implementation details to allow skilled administrators to choose and implement
 the right strategy for their institution.
 
 *On this page:*
+
 * :ref:`Scaling up: optimising on one machine <scaling-up>`
 * :ref:`Scaling out: optimising across multiple machines <scaling-out>`
 * :ref:`Process configuration strategies <config-strategies>`
@@ -350,14 +351,16 @@ performance improvements by not compressing the AIP.
 the resulting AIP is smaller, but compression also takes longer. Lower
 compression levels mean quicker compression, but a larger AIP.
 
-Preservation Action Rules
+.. _disable-fpr-rules:
+
+Preservation action rules
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Some of the default preservation action rules can take considerable processing
 time and resources. We have found the following rules useful to change in some
 cases.
 
-**Turn off default characterization rule:** FITS is used to characterise files
+**Turn off default characterization rule:** `FITS`_ is used to characterise files
 that don't have a recognised file format. Executing this rule takes processing
 time and adds raw output to the METS file that can be low value for some
 formats. For example, in scientific datasets with large numbers of generic text
@@ -396,3 +399,4 @@ to create (and check) than the alternatives (e.g. SHA-256).
 .. _Archivematica user forum: https://groups.google.com/forum/#!forum/archivematica
 .. _Dashboard: https://github.com/artefactual/archivematica/tree/6ead2083f7bdd8b10ca76d41a7bff9c5aee23eb3/src/dashboard/install
 .. _benchmarking: https://www.itforarchivists.com/siegfried/benchmarks
+.. _FITS: https://projects.iq.harvard.edu/fits/home

--- a/user-manual/administer/dashboard-admin.rst
+++ b/user-manual/administer/dashboard-admin.rst
@@ -217,7 +217,7 @@ Options:
 Examine contents
 ++++++++++++++++
 
-Run Bulk Extractor, a forensics tool that can recognize credit card numbers,
+Run `Bulk Extractor`_, a forensics tool that can recognize credit card numbers,
 social security numbers, and other patterns in data. For more information on
 reviewing Bulk Extractor logs, see the :ref:`Analysis pane <analysis_pane>` on
 the Appraisal tab.
@@ -790,3 +790,4 @@ This tab displays the version of Archivematica you're using.
 .. _Parallel bzip2 (pbzip2): https://launchpad.net/pbzip2/
 .. _`Binder`: https://binder.readthedocs.io/en/latest/contents.html
 .. _`Transifex`: https://www.transifex.com/artefactual/archivematica/
+.. _`Bulk Extractor`: https://www.forensicswiki.org/wiki/Bulk_extractor

--- a/user-manual/appraisal/appraisal.rst
+++ b/user-manual/appraisal/appraisal.rst
@@ -123,7 +123,7 @@ present in the selected files.
 3) Examine Contents
 ===================
 
-If Examine Contents (using the tool Bulk Extractor) was used during transfer,
+If Examine Contents (using the tool `Bulk Extractor`_) was used during transfer,
 the Examine Contents tab provides the reports created during this microservice.
 This tab includes options for listing files that potentially contain personally
 identifiable information (PII) or credit card numbers. Examine Contents also
@@ -379,3 +379,5 @@ remain in the Arrange pane until arrangement is complete and they are sent to
 Ingest.
 
 :ref:`Back to the top <appraisal>`
+
+.. _`Bulk Extractor`: https://www.forensicswiki.org/wiki/Bulk_extractor

--- a/user-manual/transfer/forensic.rst
+++ b/user-manual/transfer/forensic.rst
@@ -7,9 +7,9 @@ Forensic disk images
 Archivematica supports the preservation of forensic disk images. Selecting the
 disk image :ref:`transfer type <transfer-types>` is not required to preserve
 disk images - you can use the standard transfer type or the bag transfer types,
-if your disk image is also bagged. However, the disk image transfer type does
-give you an extra disk image-specific metadata form where you can record
-information about the imaging process.
+if your disk image is also bagged. The disk image transfer type gives users an
+extra disk image-specific metadata form where you can record information about
+the imaging process.
 
 *On this page*
 
@@ -44,10 +44,10 @@ in failures. We recommend not extracting forensic image formats. This can be set
 in the processing configuration by setting the *Extract packages* job to "No".
 
 If you would like to extract forensic image formats anyway, you can set the
-*Extract packages* job to "Yes". However, we recommend testing this at scale to
-ensure that it is a viable workflow for your deployment. One scalability option
-that can help to mitigate the processing load caused by extraction is turning
-off `FITS`_, which is the default characterization tool that will run on every
+*Extract packages* job to "Yes". We recommend testing this at scale to ensure
+that it is a viable workflow for your deployment. One scalability option that
+can help to mitigate the processing load caused by extraction is turning off
+`FITS`_, which is the default characterization tool that will run on every
 extracted file. For more information, see :ref:`Preservation Action Rules
 <disable-fpr-rules>` on the Scalability page.
 
@@ -67,13 +67,14 @@ Examine contents
 
 The examine contents microservice runs `Bulk Extractor`_, a forensics tool that
 can recognize credit card numbers, social security numbers, and other patterns
-in data. The microservice creates log files that can be inspected later on.
+in data. Bulk Extractor creates logs that are stored in the AIP. The logs can be
+inspected by sending the transfer to the backlog and using the Examine Contents
+functionality on the :ref:`Analysis pane <analysis_pane>` in the Appraisal tab.
 
 Examine contents is another microservice that can result in increased processing
 time, especially if it is running on the contents of an extracted forensic disk
-image. If you are not extracting contents, running Bulk Extractor is
-questionably useful, as the disk image itself is not likely to generate any
-results.
+image. If you are not extracting contents, the disk image itself is not likely
+to generate any results from Bulk Extractor.
 
 We recommend setting the *Examine contents* job to "No", so that Bulk Extractor
 does not run. If you would like to run Bulk Extractor on the extracted contents


### PR DESCRIPTION
This is a general update to the forensic disk images page. I've
clarified the rationale behind some of the processing config options
and added steps for processing compound disk images. I also cleaned up
the formatting and some of the instructions in the steps.

As a result of needing to grab links from other pages, I've also made
some small changes to appraisal.rst, dashboard-admin.rst, and
scaling-archivematica.rst, to comply with the style guidelines.

Connected to archivematica/Issues#668