### PR TITLE
Remove SWORD API sync warning

### DIFF
--- a/admin-manual/installation-setup/installation/install-centos.rst
+++ b/admin-manual/installation-setup/installation/install-centos.rst
@@ -79,14 +79,6 @@ Installation instructions
         :language: bash
         :lines: 59
 
-     .. warning:: If you are planning to use the `Sword API`_ of the
-        Archivematica Storage Service, then (due to a `known issue`_), you must
-        instruct Gunicorn to use the ``sync`` worker class:
-
-     .. code:: bash
-
-        sudo sh -c 'echo "SS_GUNICORN_WORKER_CLASS=sync" >> /etc/sysconfig/archivematica-storage-service'
-
    * After the package is installed, populate the SQLite database, and collect
      some static files used by django.  These tasks must be run as
      “archivematica” user.

--- a/admin-manual/installation-setup/installation/install-centos.rst
+++ b/admin-manual/installation-setup/installation/install-centos.rst
@@ -51,9 +51,7 @@ Installation instructions
       :language: bash
       :lines: 16-26
 
-   * Archivematica:
-
-      Use these commands to install the repositories:
+   * Archivematica - use these commands to install the repositories:
 
    .. literalinclude:: scripts/am-centos-rpm.sh
       :language: bash
@@ -251,7 +249,7 @@ the configuration of your new server.
           /usr/share/archivematica/virtualenvs/archivematica-storage-service/bin/python manage.py createsuperuser
         ";
 
-  After you have created this user, the API key will be generated automatically, and that key will connect the Archivematica pipeline to the Storage Service API. The API key can be found via the web interface (go to **Administration > Users**).
+   After you have created this user, the API key will be generated automatically, and that key will connect the Archivematica pipeline to the Storage Service API. The API key can be found via the web interface (go to **Administration > Users**).
 
 3. To finish the installation, use your web browser to navigate to the
    Archivematica dashboard using the IP address of the machine on which you have

--- a/admin-manual/installation-setup/installation/install-ubuntu.rst
+++ b/admin-manual/installation-setup/installation/install-ubuntu.rst
@@ -46,7 +46,7 @@ Ubuntu 16.04 (Xenial) and Ubuntu 18.04 (Bionic) installation instructions
    .. literalinclude:: scripts/am-bionic-deb.sh
       :language: bash
       :lines: 20-21
-  
+
 3. Update to the most recent OS release. This step will also fetch a list of
    the software from the package repositories you just added to your system.
 
@@ -59,7 +59,7 @@ Ubuntu 16.04 (Xenial) and Ubuntu 18.04 (Bionic) installation instructions
    .. literalinclude:: scripts/am-bionic-deb.sh
       :language: bash
       :lines: 26
-  
+
 5. Install Elasticsearch (optional)
 
    .. note:: Skip this step if you are planning to run Archivematica in indexless
@@ -80,14 +80,6 @@ Ubuntu 16.04 (Xenial) and Ubuntu 18.04 (Bionic) installation instructions
    .. literalinclude:: scripts/am-bionic-deb.sh
       :language: bash
       :lines: 31-32
-
-   .. warning:: If you are planning to use the `Sword API`_ of the Archivematica
-      Storage Service, then (due to a `known issue`_), you must instruct
-      Gunicorn to use the ``sync`` worker class:
-
-   .. code:: bash
-
-      sudo sh -c 'echo "SS_GUNICORN_WORKER_CLASS=sync" >> /etc/default/archivematica-storage-service'
 
 8. Update ``pip``. This is used to install Python dependencies for both the
    Storage Service and the Dashboard. This step is optional on Ubuntu 16.04, but

--- a/user-manual/administer/dashboard-admin.rst
+++ b/user-manual/administer/dashboard-admin.rst
@@ -205,7 +205,7 @@ Options:
 Perform policy checks on originals
 ++++++++++++++++++++++++++++++++++
 
-If you have created policies using :ref:`MediaConch <mediaconch>`, Archivematica
+If you have created policies using :ref:`MediaConch <fpr-mediaconch>`, Archivematica
 runs the original transfer materials against the policies to assess
 conformance.
 

--- a/user-manual/preservation/preservation-planning.rst
+++ b/user-manual/preservation/preservation-planning.rst
@@ -836,7 +836,7 @@ Validation tools
 
 Archivematica includes two validation tools: `JHOVE`_ and `MediaConch`_.
 
-.. _mediaconch:
+.. _fpr-mediaconch:
 
 MediaConch
 ^^^^^^^^^^


### PR DESCRIPTION
This removes an admonition that applied to Storage Service 0.11.0 but was resolved in SS 0.12. This
should be cherry-picked back a few versions as well.

Resolves #181