### PR TITLE
Fix CentOS dashboard upgrade instructions

### DIFF
--- a/admin-manual/installation-setup/upgrading/upgrading.rst
+++ b/admin-manual/installation-setup/upgrading/upgrading.rst
@@ -261,7 +261,7 @@ Upgrade on CentOS/Red Hat packages
               source /etc/sysconfig/archivematica-dashboard \
                   || (echo 'Environment file not found'; exit 1)
           cd /usr/share/archivematica/dashboard
-          /usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/python manage.py migrate --no-input
+          /usr/share/archivematica/virtualenvs/archivematica-dashboard/bin/python manage.py migrate --noinput
       ";
 
       sudo -u archivematica bash -c " \

--- a/admin-manual/installation-setup/upgrading/upgrading.rst
+++ b/admin-manual/installation-setup/upgrading/upgrading.rst
@@ -215,7 +215,7 @@ Upgrade on CentOS/Red Hat packages
 
    .. code:: bash
 
-      sudo apt-get remove --purge elasticsearch
+      sudo yum erase elasticsearch
       sudo mv /var/lib/elasticsearch /var/lib/elasticsearch-1.7.5
       sudo mv /etc/elasticsearch /etc/elasticsearch-1.7.5
 


### PR DESCRIPTION
When running the migration with `--no-input` it fails, changing it to the valid `--noinput` option.

Connects archivematica/issues#699