### PR TITLE
Remove reference to objects directory

### DIFF
--- a/user-manual/transfer/transfer.rst
+++ b/user-manual/transfer/transfer.rst
@@ -314,17 +314,14 @@ Checksum files should be named as follows:
 * ``checksum.sha512``.
 
 The checksum file itself should contain one line for each checksum, beginning
-with the checksum, followed by a space, followed by the file path. The file
-path must include the ``objects/`` directory in the path. It is recommended
-that the checksums are created when the files are sitting in a folder with
-this name to avoid having to manipulate the manifest afterwards::
+with the checksum, followed by two spaces, followed by the file path::
 
-  2121dca88ad7f701d3f3e2d041004a56  objects/beihai.tif
-  7f42199657dea535b6ad1963a6c7a2ac  objects/bird.mp3
-  6dc1519418859ea5c20fd708e89d7254  objects/ocr-image.png
-  4737e4dacfc9510915ea58cf12e51712  objects/View_from_lookout_over_Queenstown_towards_the_Remarkables_in_spring.jpg
-  75388a532283b988f79206d63f65e9a2  objects/subdirectory/piiTestDataCreditCardNumbers.txt
-  1d7193ea3b2193c79f55ea7e645503a9  objects/subdirectory/piiTestDataSocialSecurityNumbers.txt
+  2121dca88ad7f701d3f3e2d041004a56  beihai.tif
+  7f42199657dea535b6ad1963a6c7a2ac  bird.mp3
+  6dc1519418859ea5c20fd708e89d7254  ocr-image.png
+  4737e4dacfc9510915ea58cf12e51712  View_from_lookout_over_Queenstown_towards_the_Remarkables_in_spring.jpg
+  75388a532283b988f79206d63f65e9a2  subdirectory/piiTestDataCreditCardNumbers.txt
+  1d7193ea3b2193c79f55ea7e645503a9  subdirectory/piiTestDataSocialSecurityNumbers.txt
 
 If your checksum check fails, the *Verify transfer checksums* microservice will
 show an error and the transfer will fail. Expanding the microservice will show


### PR DESCRIPTION
Commit 6bd01e8 introduced to the text a requirement for users to
encode an 'objects/' directory in checksum manifest file paths.
This change removes that requirement following refinements to the
checksum verification microservice in Archivematica 1.10.

Connected to archivematica/issues#844
AM 1.10 PR: https://github.com/artefactual/archivematica/pull/1460
Sample data: artefactual/archivematica-sampledata#59