### PR TITLE
Removes unused TOC entry

### DIFF
--- a/admin-manual/installation-setup/upgrading/upgrading.rst
+++ b/admin-manual/installation-setup/upgrading/upgrading.rst
@@ -8,7 +8,6 @@ Upgrade from Archivematica |previous_version|.x to |release|
 
 * :ref:`Upgrade Ubuntu package install <upgrade-ubuntu>`
 * :ref:`Upgrade CentOS/Red Hat package install <upgrade-centos>`
-* :ref:`Upgrade search indices <upgrade-search-indices>`
 * :ref:`Upgrade in indexless mode <upgrade-indexless>`
 * :ref:`Upgrade with output capturing disabled <upgrade-no-output-capture>`
 


### PR DESCRIPTION
During a previous edit, the section *Upgrade search indices <upgrade-search-indices>* was removed, but the entry was not removed from the TOC at the top of this page.