### PR TITLE
Allow Travis warning checks to continue past first warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ language: python
 python:
   - "2.7"
 script:
-  - "sphinx-build -n -W -b html -d _build/doctrees . _build/html"
+  - "sphinx-build -n -W --keep-going -b html -d _build/doctrees . _build/html"


### PR DESCRIPTION
Seeks to resolve https://github.com/archivematica/Issues/issues/970

Just a note: This flag was added in Sphinx 1.8, and Travis runs 1.8.5. However, I did have to update my local Sphinx from an older version to test this out. @sallain or others may have to do that too.