### PR TITLE
updates to DIP Upload with AtoM Levels of Description

### DIFF
--- a/user-manual/access/access.rst
+++ b/user-manual/access/access.rst
@@ -80,6 +80,15 @@ using either the metadata form or the metadata CSV file. This descriptive
 metadata will be passed to AtoM. Note that the AtoM DIP upload integration
 supports Dublin Core descriptive metadata only.
 
+.. note::
+
+  Adding metadata through the form in Archivematica will create an intermediary
+  descripton in AtoM. However, if the transfer is sent to the backlog and AtoM
+  descriptions are applied (see :ref:`Adding AtoM levels of description
+  <adding-atom-lod>`), then any metadata added through the form will not be
+  present in AtoM. There will also be no intermediary description, but the
+  levels of description you applied will be present in AtoM.
+
 There are two ways to provide the target description to Archivematica. The first
 is by providing the slug during the Upload DIP microservice.
 

--- a/user-manual/appraisal/appraisal.rst
+++ b/user-manual/appraisal/appraisal.rst
@@ -584,6 +584,9 @@ This functionality is supported with AtoM 2.2 and higher.
    arrange, AtoM will flatten the DIP so that all digital objects are
    child-level descriptions of the target description.
 
+   If you add levels of description to the SIP then metadata added through the
+   form in Archivematica will not be included in the DIP.
+
 .. _creating-sips-tags:
 
 Creating a SIP using tags


### PR DESCRIPTION
Made clarifications to adding metadata via the GUI form in Archivematica and creating AtoM levels of description via the appraisal tab.

Changes were made to both the access and appraisal documents.

This is related to documentation issue 858: https://github.com/archivematica/Issues/issues/858