### PR TITLE
Add web service requirement to PID binding docs

### DIFF
--- a/admin-manual/installation-setup/customization/dashboard-config.rst
+++ b/admin-manual/installation-setup/customization/dashboard-config.rst
@@ -756,6 +756,12 @@ registry. Handle.Net can then create persistent URLs (PURLs) from the PIDs and
 can reroute requests to the persistent URLs to a target URL that is configured
 in Handle.Net.
 
+.. note::
+
+   In order to use the Handle.Net configuration, you will need to provide an
+   available web service. See the `PID webservice being used by IISH`_ for an
+   example of a compatible webservice.
+
 .. image:: images/handlenet-config.*
    :align: right
    :width: 45%
@@ -861,3 +867,4 @@ This tab displays the version of Archivematica you're using.
 .. _automation tools: https://github.com/artefactual/automation-tools
 .. _Binder: https://binder.readthedocs.io/en/latest/contents.html
 .. _Transifex: https://www.transifex.com/artefactual/archivematica/
+.. _PID webservice being used by IISH:

--- a/admin-manual/installation-setup/customization/dashboard-config.rst
+++ b/admin-manual/installation-setup/customization/dashboard-config.rst
@@ -760,7 +760,7 @@ in Handle.Net.
 
    In order to use the Handle.Net configuration, you will need to provide an
    available web service. See the `PID webservice being used by IISH`_ for an
-   example of a compatible webservice.
+   example of a compatible web service.
 
 .. image:: images/handlenet-config.*
    :align: right


### PR DESCRIPTION
I've only added this in one place - the configuration documentation -
because every other place that PID binding is mentioned ends up here
eventually. I think it's sufficient.

Will also cherry-pick back to 1.10.

Connected to archivematica/Issues#1046