### PR TITLE
Update sanitize/clean up names microservice wording

### DIFF
--- a/user-manual/index.rst
+++ b/user-manual/index.rst
@@ -15,7 +15,7 @@ links to each chapter's main sections.
    transfer/forensic
    transfer/dspace
    transfer/scan-for-viruses
-   transfer/clean-up-names
+   transfer/change-filenames
    transfer/dataverse
    ingest/ingest
    ingest/manual-normalization

--- a/user-manual/ingest/manual-normalization.rst
+++ b/user-manual/ingest/manual-normalization.rst
@@ -383,10 +383,12 @@ Subdirectories used only to distinguish file names:
    file1.tga,manualNormalization/access/subdir1/file1.jpg,manualNormalization/preservation/subdir1/file1.tif
    file1.ppm,manualNormalization/access/subdir2/file1.jpg,manualNormalization/preservation/subdir2/file1.tif
 
-If the file names contain spaces or forbidden characters, Archivematica will
-sanitize the file names by replacing the spaces/characters with underscores. The
-normalization.csv file will still work by using either the original, unsanitized
-file names, or by pre-sanitizing the normalized filenames and the corresponding
-columns in normalization.csv.
+.. note::
+
+   If the filenames contain characters that Archivematica's toolset cannot
+   handle, Archivematica will change the filenames by replacing the character
+   with the nearest equivalent (see :ref:`Filename changes <change-filenames>`
+   for more information.) The normalization.csv file will work with either the
+   original filenames or the changed filenames.
 
 :ref:`Back to the top <manual-norm>`

--- a/user-manual/transfer/change-filenames.rst
+++ b/user-manual/transfer/change-filenames.rst
@@ -1,20 +1,20 @@
-.. _clean-up-names:
+.. _change-filenames:
 
-==============
-Clean up names
-==============
+================
+Filename changes
+================
 
-The clean up names microservice runs twice during processing - once on the
+The change filenames microservice runs twice during processing - once on the
 Transfer tab and once on the Ingest tab. The purpose of this microservice is to
 ensure that Archivematica's tools and processes do not fail because of
-characters that appear in file or directory names.
+characters that appear in object and directory names.
 
-Archivematica groups a wide variety of tools, such as :ref:` preservation
+Archivematica groups a wide variety of tools, such as :ref:`preservation
 planning tools <preservation-planning-tools>`, together to create preservation
 workflows. Some of the tools that Archivematica uses have a narrowly-defined
 scope in terms of what the tool considers to be a valid character for a file or
 directory name. Encountering a character that the tool considers to be invalid
-can cause the tool to fail, which can halt processing and interfere with normal
+can cause the tool to fail, which can halt processing and prevent the normal
 operation of Archivematica.
 
 To prevent these kinds of failures from happening, Archivematica implements
@@ -65,15 +65,15 @@ Additional information can be found in the complete PREMIS event:
    </mets:mdWrap>
 
 This strategy for addressing character limitations within the tools bundled by
-Archivematica can result in file and directory names can result in significant
-changes to file and directory names. In order to provide easy access to a record
-of the changes, the Archivematica AIP contains log files that show the original
-name alongside the changed name. There are two log files:
+Archivematica can result in significant changes to file and directory names. In
+order to provide easy access to a record of the changes, the Archivematica AIP
+contains log files that show the original name alongside the changed name. There
+are two log files:
 
-* The log file for name changes that happen during Transfer is located at
-  ``data/logs/transfers/my-transfer-name/logs/filenameCleanup.log``
-* The log file for name changes that happen during Ingest is located at
-  ``data/logs/filenameCleanup.log``
+* The log file for name changes that happen during Transfer is located in the
+  AIP at ``data/logs/transfers/my-transfer-name/logs/filenameCleanup.log``
+* The log file for name changes that happen during Ingest is located in the AIP
+  at ``data/logs/filenameCleanup.log``
 
 These logs contain a plaintext rendering of the information embedded within the
 PREMIS event.
@@ -86,3 +86,5 @@ PREMIS event.
    Sanitized name: %transferDirectory%objects/Česká republika.ong  ->  %transferDirectory%objects/Ceska_republika.ong
    Sanitized name: %transferDirectory%objects/Ísland.png  ->  %transferDirectory%objects/Island.png
    Sanitized name: %transferDirectory%objects/España.png  ->  %transferDirectory%objects/Espana.png
+
+:ref:`Back to the top <change-filenames>`

--- a/user-manual/transfer/transfer.rst
+++ b/user-manual/transfer/transfer.rst
@@ -568,9 +568,9 @@ The microservices that run on the Transfer tab include:
 * **Generate transfer structure report**: generates a directory tree of the
   original transfer and places as a text file in the AIP.
 
-* **Clean up names**: removes prohibited characters from folder and filenames,
-  such as ampersands. For more information, see :ref:`Clean up names
-  <clean-up-names>`.
+* **Change transfer filenames**: removes prohibited characters from folder and
+  filenames, such as ampersands. For more information, see :ref:`Change
+  filenames <change-filenames>`.
 
 * **Identify file format**: allows the user to choose whether or not to
   identify file formats. Selecting "Yes" will prompt the enabled file


### PR DESCRIPTION
This change updates the documentation in line with archivematica/Issues#230, which changes the wording used for the "clean up names" microservices to use "change filenames" instead.

I have created a related issue that describes the need to change the log output - archivematica/Issues#1079

Connected to archivematica/Issues#230