### PR TITLE
Expand maintenance documentation

### DIFF
--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -270,7 +270,7 @@ repository-type specific:
 
 .. code:: bash
 
-  curl -XPUT 'http://localhost:9200/_snapshot/es_backup_YOUR-NAME' -d '{
+  curl -XPUT -H 'Content-Type: application/json' 'http://localhost:9200/_snapshot/es_backup_YOUR-NAME' -d '{
       "type": "fs",
       "settings": {
           "compress" : true,
@@ -286,7 +286,7 @@ is taken. For example, using the date inside the filename:
 
 .. code:: bash
 
-  curl -XPUT "http://localhost:9200/_snapshot/es_backup_YOUR-NAME/%3Csnapshot-am-%7Bnow%2Fd%7D%3E?wait_for_completion=true" -d'
+  curl -XPUT -H 'Content-Type: application/json' 'http://localhost:9200/_snapshot/es_backup_YOUR-NAME/%3Csnapshot-am-%7Bnow%2Fd%7D%3E?wait_for_completion=true' -d'
   {
     "indices": "aips,aipfiles,transfers,transferfiles",
     "ignore_unavailable": true,
@@ -305,13 +305,13 @@ To list all the snapshots:
 
 .. code:: bash
 
-  curl -XGET "https://localhost:9200/_snapshot/es_backup_YOUR-NAME/_all"
+  curl -XGET 'http://localhost:9200/_snapshot/es_backup_YOUR-NAME/_all?pretty=true'
 
 To delete a snapshot:
 
 .. code:: bash
 
-  curl DELETE "https://localhost:9200/_snapshot/es_backup_YOUR-NAME/snapshot-am-YYYY.MM.DD"
+  curl -XDELETE 'http://localhost:9200/_snapshot/es_backup_YOUR-NAME/snapshot-am-YYYY.MM.DD'
 
 **Restoring Elasticsearch**
 
@@ -326,7 +326,7 @@ index, post to the following _close endpoints, like so:
 
 .. code:: bash
 
-  curl -XPOST "http://localhost:9200/aips,aipfiles,transfers,transferfiles/_close" -d'
+  curl -XPOST -H 'Content-Type: application/json' 'http://localhost:9200/aips,aipfiles,transfers,transferfiles/_close' -d'
   {
     "ignore_unavailable": true
   }'
@@ -335,7 +335,7 @@ To restore ElasticSearch:
 
 .. code:: bash
 
-  curl -XPOST 'http://localhost:9200/_snapshot/es_backup_clientname/snapshot-am-YYYY.MM.DD/_restore'
+  curl -XPOST 'http://localhost:9200/_snapshot/es_backup_YOUR-NAME/snapshot-am-YYYY.MM.DD/_restore'
 
 
 .. _admin-faq:
@@ -369,7 +369,7 @@ taken to recover.
 
 .. code:: bash
 
-    curl -XPUT -H "Content-Type: application/json" http://localhost:9200/_all/_settings -d '{"index.blocks.read_only_allow_delete":null}'
+    curl -XPUT -H 'Content-Type: application/json' 'http://localhost:9200/_all/_settings' -d '{"index.blocks.read_only_allow_delete":null}'
 
 
 .. _restart-services:

--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -160,7 +160,7 @@ Data to back up from an Archivematica instance:
 
 #. MCP database (see below for details)
 #. SS database (see below for details)
-#. Elasticsearch index/indices (see below for details)
+#. Elasticsearch indexes (see below for details)
 #. Pointer files (in the Storage Service internal processing location; the
    default location is ``/var/archivematica/storage_service``)
 #. AM config in ``/etc/archivematica``
@@ -285,13 +285,6 @@ To make a backup (snapshot) for the ``aips``, ``aipfiles``, ``transfer`` and
 is taken. For example, using the date inside the filename:
 
 .. code:: bash
-
-  curl -XPUT "http://localhost:9200/_snapshot/es_backup_YOUR-NAME/snapshot_aips_20170726?wait_for_completion=true" -d'
-  {
-    "indices": "aips",  
-    "ignore_unavailable": true,
-    "include_global_state": false
-  }'
 
   curl -XPUT "http://localhost:9200/_snapshot/es_backup_YOUR-NAME/%3Csnapshot-am-%7Bnow%2Fd%7D%3E?wait_for_completion=true" -d'
   {

--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -695,5 +695,5 @@ and investigate if this happens.
 .. _`Elasticsearch troubleshooting`: https://www.accesstomemory.org/docs/latest/admin-manual/maintenance/elasticsearch/#maintenance-elasticsearch
 .. _`Kibana`: https://www.elastic.co/products/kibana
 .. _`Dejavu`: https://github.com/appbaseio/dejavu
-.. _`remove transfers or SIPs`: https://www.archivematica.org/en/docs/archivematica-1.7/user-manual/transfer/transfer/#cleaning-up-the-transfer-dashboard
+.. _`remove transfers or SIPs`: https://www.archivematica.org/en/docs/latest/user-manual/transfer/transfer/#cleaning-up-the-transfer-dashboard
 .. _`archivematica-devtools`: https://github.com/artefactual/archivematica-devtools

--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -166,40 +166,42 @@ FAQ
 How to restart the Archivematica services
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**Restart all services**
+Archivematica is made up of these four core components:
 
 .. code:: bash
 
-   am services
+    archivematica-mcp-server
+    archivematica-mcp-client
+    archivematica-dashboard
+    archivematica-storage-service
 
-Note that the default action is to restart all services. To see other available
-parameters, type:
+Other services that Archivematica depends on are:
+  * ClamAV
+  * ElasticSearch
+  * Gearman
+  * MySQL (Ubuntu) or MariaDB (CentOS)
+  * Nailgun
+  * Nginx
 
-.. code:: bash
-
-   am services help
-
-**Stopping**
-
-.. code:: bash
-
-   sudo stop archivematica-mcp-server
-   sudo stop archivematica-mcp-client
-   sudo /etc/init.d/apache2 stop
-   sudo /etc/init.d/gearman-job-server stop
-   sudo stop mysql
-   sudo /etc/init.d/elasticsearch stop
-
-**Starting**
+Each service can be started/stopped/restarted with:
 
 .. code:: bash
 
-   sudo /etc/init.d/elasticsearch start
-   sudo start mysql
-   sudo /etc/init.d/gearman-job-server start
-   sudo /etc/init.d/apache2 start
-   sudo start archivematica-mcp-server
-   sudo start archivematica-mcp-client
+    service <name> start|stop|status|restart
+
+To restart all services, restart the Gearman service and each Archivematica
+component, in this order:
+
+.. code:: bash
+
+    service gearmand restart
+    service archivematica-mcp-server restart
+    service archivematica-mcp-client restart
+    service archivematica-dashboard restart
+    service archivematica-storage-service restart
+
+**Note: Depending on your installation, gearmand might be called gearman-job-server.**
+
 
 .. _stack-trace:
 

--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -320,6 +320,10 @@ How to clean up a full disk
     "My Archivematica disk filled up and now Archivematica won't work. How can I
     fix this?"
 
+Archivematica servers have as much storage as they have been commissioned. If
+processing lots of very large files, particularly if working with normalization,
+this will cause the disk to fill up and cause the system to malfunction.
+
 When the disk on an Archivematica instance is full, a number of steps need to be
 taken to recover. 
 

--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -162,25 +162,25 @@ Data to back up from an Archivematica instance:
 #. SS database (see below for details)
 #. Elasticsearch index (see below for details)
 #. Pointer files (in the Storage Service internal processing location; the
-   default location is /var/archivematica/storage_service)
-#. AM config in /etc/archivematica
+   default location is ``/var/archivematica/storage_service``)
+#. AM config in ``/etc/archivematica``
 #. defaultProcessingMCP.xml (processing configuration, in 
-   /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs) 
+   ``/var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs``) 
 
 
 If doing an update or migration of Archivematica to a new server, the following
 may also be important to back up:
 
-#. Archivematica source code (/opt/archivematica ) (to know which version of the
-   software was installed, if there were custom changes, etc.)
-#. Archivematica shared directory (/var/archivematica/sharedDirectory/)
+#. Archivematica source code (``/opt/archivematica``) (to know which version of
+   the software was installed, if there were custom changes, etc.)
+#. Archivematica shared directory (``/var/archivematica/sharedDirectory/``)
 
 If your instance uses automation-tools, that should also be backed up:
 
-#. Source code ( /opt/archivematica/automation-tools)
-#. Scripts (normally in /etc/archivematica/automation-tools)
+#. Source code (``/opt/archivematica/automation-tools``)
+#. Scripts (normally in ``/etc/archivematica/automation-tools``)
 #. Crontab entries for automation-tools 
-#. Automation database (normally in /var/archivematica/automation-tools/)
+#. Automation database (normally in ``/var/archivematica/automation-tools/``)
 #. Any other helper scripts source and databases
 
 
@@ -195,7 +195,7 @@ database by using the following command:
    mysqldump -u <your username> -p <your password> -c MCP > <filename of backup>
 
 
-To restore from mysqldump file:
+To restore from ``mysqldump`` file:
 
 .. code:: bash
 
@@ -212,7 +212,7 @@ To backup the SQLite database and pointer files created by the storage service r
   rsync -av /var/archivematica/storage-service/storage.db /backup/location/storage.db
 
 Note: The Storage Service must not be actively in use. Make sure the
-Storage Service is not running by stopping the nginx or storage-service
+Storage Service is not running by stopping the ``nginx`` or ``storage-service``
 services or by making the backup at a time that it is not in use.
 
 To restore Storage Service from backup:
@@ -234,7 +234,7 @@ backing up and restoring Elasticsearch are available in the
 **Preconfiguration**
 
 The path.repo and snapshot repository have to be configured. For example, using
-/var/lib/elasticsearch/backup-repo as the repo path:
+``/var/lib/elasticsearch/backup-repo`` as the repo path:
 
 .. code:: bash
 
@@ -242,7 +242,7 @@ The path.repo and snapshot repository have to be configured. For example, using
   chmod 0755 /var/lib/elasticsearch/backup-repo
   chown elasticsearch:elasticsearch /var/lib/elasticsearch/backup-repo
 
-Add this line to the /etc/elasticsearch/elasticsearch.yml file:
+Add this line to the ``/etc/elasticsearch/elasticsearch.yml`` file:
 
 .. code:: bash
 
@@ -278,7 +278,7 @@ repository-type specific:
 
 **Backing up Elasticsearch indexes**
 
-To make a backup (snapshot) for the aips and transfer indexes, a different name
+To make a backup (snapshot) for the ``aips`` and ``transfer`` indexes, a different name
 has to be used every time a snapshot is taken. For example, using the date
 inside the filename:
 
@@ -298,7 +298,9 @@ inside the filename:
     "include_global_state": false
   }'
 
-The snapshot will be saved to the /var/lib/elasticsearch/backup-repo/es_backup_clientname directory. This directory can be backed up, for example, using rsync:
+The snapshot will be saved to the
+``/var/lib/elasticsearch/backup-repo/es_backup_clientname`` directory. This
+directory can be backed up, for example, using rsync:
 
 .. code:: bash
 
@@ -316,13 +318,16 @@ To delete a snapshot:
 
   curl DELETE "https://localhost:9200/_snapshot/es_backup_clientname/snapshot_transfers_20170726"
 
-For more information about ElasticSearch: https://www.elastic.co/guide/en/elasticsearch/reference/1.6/modules-snapshots.html
-
 **Restoring Elasticsearch**
 
-Before restoring, the snapshot repo has to be registered in elasticsearch (see preconfiguration). It can be restored in a different server, configuring the repo.path, registering the snapshot repo (different paths and repo names can be used) and copying the files inside the /backup/location/elasticsearch directory.
+Before restoring, the snapshot repo has to be registered in elasticsearch (see
+preconfiguration). It can be restored in a different server, configuring the
+repo.path, registering the snapshot repo (different paths and repo names can be
+used) and copying the files inside the ``/backup/location/elasticsearch``
+directory.
 
-The index will have to be closed before restoration can occur. To close the index, post to the following _close endpoints, like so:
+The index will have to be closed before restoration can occur. To close the
+index, post to the following _close endpoints, like so:
 
 .. code:: bash
 
@@ -333,10 +338,8 @@ To restore ElasticSearch:
 
 .. code:: bash
 
-  curl -XPOST 'http://localhost:9200/_snapshot/es_backup_clientname
-  /snapshot_aips_20170726/_restore'
+  curl -XPOST 'http://localhost:9200/_snapshot/es_backup_clientname/snapshot_aips_20170726/_restore'
   curl -XPOST 'http://localhost:9200/_snapshot/es_backup_clientname/snapshot_transfers_20170726/_restore'
-
 
 
 .. _admin-faq:
@@ -361,7 +364,7 @@ taken to recover.
 **Recovery protocol**
 
 #. Clean up the disk by removing failed or rejected transfers, any excessive
-   /tmp data, or anything else causing the disk to have filled up.
+   ``/tmp`` data, or anything else causing the disk to have filled up.
 #. Reset MySQL (or MariaDB, on CentOS) database.
 #. Reset Archivematica components in appropriate order (see `restart-services`_
    for details).
@@ -414,7 +417,9 @@ component, in this order:
     service archivematica-dashboard restart
     service archivematica-storage-service restart
 
-**Note: Depending on your installation, gearmand might be called gearman-job-server.**
+.. note::
+
+  Depending on your installation, gearmand might be called gearman-job-server.
 
 
 .. _stack-trace:

--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -145,13 +145,44 @@ The index names are: `aips`, `aipfiles`, `transfers` and `transferfiles`.
 Data backup
 -----------
 
-By default, Archivematica there are three types of data you'll likely want to back up:
+By default, there are three types of data that should be backed up:
 
 * Filesystem (particularly your storage directories)
 
 * MySQL and SQLite
 
 * Elasticsearch
+
+In addition to the filesystem, below are some detailed instructions of what to
+back up, where it exists, and how to do it.
+
+Data to back up from an Archivematica instance:
+
+#. MCP database (see below for details)
+#. SS database (see below for details)
+#. Elasticsearch index (see below for details)
+#. Pointer files (in the Storage Service internal processing location; the
+   default location is /var/archivematica/storage_service)
+#. AM config in /etc/archivematica
+#. defaultProcessingMCP.xml (processing configuration, in 
+   /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs) 
+
+
+If doing an update or migration of Archivematica to a new server, the following
+may also be important to back up:
+
+#. Archivematica source code (/opt/archivematica ) (to know which version of the
+   software was installed, if there were custom changes, etc.)
+#. Archivematica shared directory (/var/archivematica/sharedDirectory/)
+
+If your instance uses automation-tools, that should also be backed up:
+
+#. Source code ( /opt/archivematica/automation-tools)
+#. Scripts (normally in /etc/archivematica/automation-tools)
+#. Crontab entries for automation-tools 
+#. Automation database (normally in /var/archivematica/automation-tools/)
+#. Any other helper scripts source and databases
+
 
 Archivematica Database backup and restore
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -211,9 +211,11 @@ To backup the SQLite database and pointer files created by the storage service r
   rsync -av /var/archivematica/storage_service /backup/location/storage_service
   rsync -av /var/archivematica/storage-service/storage.db /backup/location/storage.db
 
-Note: The Storage Service must not be actively in use. Make sure the
-Storage Service is not running by stopping the ``nginx`` or ``storage-service``
-services or by making the backup at a time that it is not in use.
+.. note::
+
+  The Storage Service must not be actively in use. Make sure the
+  Storage Service is not running by stopping the ``nginx`` or ``storage-service``
+  services or by making the backup at a time that it is not in use.
 
 To restore Storage Service from backup:
 

--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -17,6 +17,12 @@ installation.
 * :ref:`Data backup <data-backup>`
 * :ref:`FAQ <admin-faq>`
 
+  * :ref:`Restart Services <restart-services>`
+  * :ref:`Error stack trace <stack-trace>`
+  * :ref:`Resolve hanging decisions <hanging-decisions>`
+  * :ref:`Transfer won't start <transfer-wont-start>`
+
+
 .. _elasticsearch:
 
 Maintaining Elasticsearch
@@ -242,6 +248,8 @@ edit a configuration file from the command line.
 7. Debug or report error
 
 8. Restore DEBUG to False and restart Apache to turn error reporting off again
+
+.. _hanging-decisions:
 
 Resolve hanging decisions
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -9,15 +9,17 @@ installation.
 
 *On this page:*
 
-* :ref:`Elasticsearch <elasticsearch>`
+* :ref:`Maintaining Elasticsearch <elasticsearch>`
 
-  * :ref:`Rebuild the indexes <elasticsearch-indexes>`
-  * :ref:`External access <elasticsearch-external>`
+  * :ref:`Rebuild Elasticsearch indexes <elasticsearch-indexes>`
+  * :ref:`External Elasticsearch access <elasticsearch-external>`
 
 * :ref:`Data backup <data-backup>`
+
 * :ref:`FAQ <admin-faq>`
 
-  * :ref:`Restart Services <restart-services>`
+  * :ref:`How to clean up a full disk <disk-full>`
+  * :ref:`How to restart services <restart-services>`
   * :ref:`Error stack trace <stack-trace>`
   * :ref:`Resolve hanging decisions <hanging-decisions>`
   * :ref:`Transfer won't start <transfer-wont-start>`
@@ -167,10 +169,39 @@ backing up and restoring Elasticsearch are available in the
 FAQ
 ---
 
+.. _disk-full:
+
+How to clean up a full disk
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    "My Archivematica disk filled up and now Archivematica won't work. How can I
+    fix this?"
+
+When the disk on an Archivematica instance is full, a number of steps need to be
+taken to recover. 
+
+**Recovery protocol**
+
+#. Clean up the disk by removing failed or rejected transfers, any excessive
+   /tmp data, or anything else causing the disk to have filled up.
+#. Reset MySQL (or MariaDB, on CentOS) database.
+#. Reset Archivematica components in appropriate order (see `restart-services`_
+   for details).
+#. Set ElasticSearch back into write mode. The easiest way to do this is to run
+   the following command:
+
+.. code:: bash
+
+    curl -XPUT -H "Content-Type: application/json"
+    http://localhost:9200/_all/_settings -d
+    '{"index.blocks.read_only_allow_delete":null}'
+
+
 .. _restart-services:
 
-How to restart the Archivematica services
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+How to restart services
+^^^^^^^^^^^^^^^^^^^^^^^
+    "Something is not working right, or I need to stop a hanging transfer. What
+    can I do?"
 
 Archivematica is made up of these four core components:
 

--- a/index.rst
+++ b/index.rst
@@ -279,9 +279,20 @@ Installation and setup
 Maintenance
 -----------
 
-* :ref:`Elasticsearch <elasticsearch>`
-* :ref:`Data back-up <data-backup>`
+* :ref:`Maintaining Elasticsearch <elasticsearch>`
+
+  * :ref:`Rebuild Elasticsearch indexes <elasticsearch-indexes>`
+  * :ref:`External Elasticsearch access <elasticsearch-external>`
+
+* :ref:`Data backup <data-backup>`
+
 * :ref:`FAQ <admin-faq>`
+
+  * :ref:`How to clean up a full disk <disk-full>`
+  * :ref:`How to restart services <restart-services>`
+  * :ref:`Error stack trace <stack-trace>`
+  * :ref:`Resolve hanging decisions <hanging-decisions>`
+  * :ref:`Transfer won't start <transfer-wont-start>`
 
 
 .. _home-security:


### PR DESCRIPTION
This is part of my effort to move internal or [open-but-unofficial](https://docs.google.com/document/d/1NDzGHBGuPFa7GTHCMEl3D2nvvdZRxG2FpdsGAYoG31I/edit#heading=h.ih2avcqb8g1a) documentation into the public! This is how I have been instructed to manage these tasks, and this is what i recommend to folks who want to take these actions. They may need a review to make sure they are still accurate for the 1.11 release, as much of this knowledge was collected for the 1.8 release.

This is connected to https://github.com/archivematica/Issues/issues/1080. For context into why I am replacing the previous commands, see that issue!