### PR TITLE
Update and reformat MediaConch instructions

### DIFF
--- a/user-manual/preservation/preservation-planning.rst
+++ b/user-manual/preservation/preservation-planning.rst
@@ -261,7 +261,7 @@ the script is, we recommend testing your script thoroughly before using it in
 a production environment.
 
 Further down on this page, there is information about each section of the
-Preservation Planning ta, which contains specific information regarding the
+Preservation Planning tab, which contains specific information regarding the
 commands for each section.
 
 To add a new command, decide which purpose your command will fulfill (i.e.


### PR DESCRIPTION
I've reformatted the MediaConch instructions so that the numbering renders
properly on the website. I've also updated the instructions for clarity
and used the example policy that is contained in the sampledata.

Connected to archivematica/Issues#780