### PR TITLE
Change text screenshots to literals

### DIFF
--- a/user-manual/transfer/scripts/identifier-mets.xml
+++ b/user-manual/transfer/scripts/identifier-mets.xml
@@ -1,0 +1,32 @@
+<mets:techMD ID="techMD_4">
+  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+    <mets:xmlData>
+      <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+        <premis:objectIdentifier>
+          <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+          <premis:objectIdentifierValue>2251bc66-85c1-4d64-952e-b0d7ea2db385</premis:objectIdentifierValue>
+        </premis:objectIdentifier>
+        <premis:objectIdentifier>
+          <premis:objectIdentifierType>EXID</premis:objectIdentifierType>
+          <premis:objectIdentifierValue>https://example.com/file/id/2367652602</premis:objectIdentifierValue>
+        </premis:objectIdentifier>
+      </premis:object>
+    </mets:xmlData>
+  </mets:mdWrap>
+</mets:techMD>
+<mets:techMD ID="techMD_5">
+  <mets:mdWrap MDTYPE="PREMIS:OBJECT">
+    <mets:xmlData>
+      <premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+        <premis:objectIdentifier>
+          <premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+          <premis:objectIdentifierValue>480d31e0-f57f-4254-a5bf-c813ed5734d5</premis:objectIdentifierValue>
+        </premis:objectIdentifier>
+        <premis:objectIdentifier>
+          <premis:objectIdentifierType>ULID</premis:objectIdentifierType>
+          <premis:objectIdentifierValue>01D9T8NGAQ2DBN8M4D23HM5FYN</premis:objectIdentifierValue>
+        </premis:objectIdentifier>
+      </premis:object>
+    </mets:xmlData>
+  </mets:mdWrap>
+</mets:techMD>

--- a/user-manual/transfer/scripts/identifiers.json
+++ b/user-manual/transfer/scripts/identifiers.json
@@ -1,0 +1,20 @@
+[
+    {
+        "file": "objects/bird.mp3",
+        "identifiers": [
+            {
+                "identifier": "01D9T8NGAQ2DBN8M4D23HM5FYN",
+                "identifierType": "ULID"
+            }
+        ]
+    },
+    {
+        "file": "objects/beihai.tif",
+        "identifiers": [
+            {
+                "identifier": "https://example.com/file/id/2367652602",
+                "identifierType": "EXID"
+            }
+        ]
+    }
+]

--- a/user-manual/transfer/transfer.rst
+++ b/user-manual/transfer/transfer.rst
@@ -366,32 +366,33 @@ click on the gear icon for the job.
 Transfers with existing persistent identifiers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Archivematica can import persistent identifiers that were created
-outside of Archivematica, such as DOI identifiers or
-identifiers created by your cataloging system. You can bind these to the
-PREMIS objects created by Archivematica for your files by including an
-identifiers.json file in the metadata sub-directory.
+Archivematica can import persistent identifiers that were created outside of
+Archivematica, such as DOI identifiers or identifiers created by your cataloging
+system. You can bind these to the PREMIS objects created by Archivematica for
+your files by including an ``identifiers.json`` file in the transfer's metadata
+directory.
 
-.. image:: images/identifiers.json.*
-  :align: center
-  :width: 50%
-  :alt: A transfer containing an identifiers.json file
+.. literalinclude:: scripts/identifiers.json
+   :language: json
 
-These persistent identifiers (PID) will be added during the Ingest `Process
-metadata directory` microservice.
+The ``identifiers.json`` file is parsed during the *Process metadata directory*
+microservice on the Ingest tab.
 
 .. image:: images/load-persistent-identifiers.*
   :align: center
-  :width: 50%
+  :width: 80%
   :alt: The persistent identifier (PID) from identifiers.json are parsed and loaded during the 'Process metadata directory' microservice
 
-Once Ingest completes, the PID will be linked to the premis:objectIdentifier in
-the AIP METS file.
+Once the AIP has been created, the identifier will be linked as a
+``premis:objectIdentifier`` within the ``techMD`` for each object within the AIP
+METS file.
 
-.. image:: images/PID_linked_to_PREMIS.*
-  :align: center
-  :width: 50%
-  :alt: PIDs linked to PREMIS objects
+.. literalinclude:: scripts/identifier-mets.xml
+   :language: xml
+
+For more information on how metadata elements are encoded used in Archivematica,
+please see :ref:`METS in Archivematica <mets_schema>` and :ref:`PREMIS metadata
+in Archivematica <premis-template>`.
 
 .. _transfer-derivatives:
 


### PR DESCRIPTION
This is just a quick update to change screenshots of text to use scripts
passed via literals instead, as per the style guide.

I've also added a reference to the METS and PREMIS documentation :tada: