### PR TITLE
Update metadata scripts for METS and PREMIS versions

### DIFF
--- a/user-manual/metadata/premis.rst
+++ b/user-manual/metadata/premis.rst
@@ -143,7 +143,7 @@ This PREMIS Event will be recorded on all extracted files:
 
 .. literalinclude:: scripts/PREMISevents.xml
    :language: xml
-   :lines: 1-13
+   :lines: 1-14
 
 .. _event-ocr:
 

--- a/user-manual/metadata/scripts/PREMISevents.xml
+++ b/user-manual/metadata/scripts/PREMISevents.xml
@@ -1,36 +1,36 @@
-<mets:digiprovMD ID="digiprovMD_85">
+<mets:digiprovMD ID="digiprovMD_54">
   <mets:mdWrap MDTYPE="PREMIS:EVENT">
     <mets:xmlData>
-      <premis:event xmlns:premis="info:lc/xmlns/premis-v2" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd" version="2.2">
+      <premis:event xmlns:premis="http://www.loc.gov/premis/v3" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
         <premis:eventIdentifier>
           <premis:eventIdentifierType>UUID</premis:eventIdentifierType>
-          <premis:eventIdentifierValue>242df66e-60d0-421e-ac34-c45252b2f80e</premis:eventIdentifierValue>
+          <premis:eventIdentifierValue>bfeecc68-855c-41ad-a628-37c2a1fb2142</premis:eventIdentifierValue>
         </premis:eventIdentifier>
         <premis:eventType>unpacking</premis:eventType>
-        <premis:eventDateTime>2019-06-06T13:15:20.853431+00:00</premis:eventDateTime>
-        <premis:eventDetail>Unpacked from: %transferDirectory%objects/Project.zip (ab3cba73-16e0-45e9-8028-1785811e9a15)</premis:eventDetail>
+        <premis:eventDateTime>2020-03-05T18:02:26.966342+00:00</premis:eventDateTime>
+        <premis:eventDetailInformation>
+          <premis:eventDetail>Unpacked from: %transferDirectory%objects/Project.zip (63706dd1-6f8f-4460-a5a5-546bac061d91)</premis:eventDetail>
+        </premis:eventDetailInformation>
         <premis:eventOutcomeInformation>
-          <premis:eventOutcome/>
+          <premis:eventOutcome></premis:eventOutcome>
           <premis:eventOutcomeDetail>
-            <premis:eventOutcomeDetailNote/>
+            <premis:eventOutcomeDetailNote></premis:eventOutcomeDetailNote>
           </premis:eventOutcomeDetail>
         </premis:eventOutcomeInformation>
         <premis:linkingAgentIdentifier>
           <premis:linkingAgentIdentifierType>preservation system</premis:linkingAgentIdentifierType>
-          <premis:linkingAgentIdentifierValue>Archivematica-1.9.1</premis:linkingAgentIdentifierValue>
+          <premis:linkingAgentIdentifierValue>Archivematica-1.11</premis:linkingAgentIdentifierValue>
         </premis:linkingAgentIdentifier>
         <premis:linkingAgentIdentifier>
           <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>
-          <premis:linkingAgentIdentifierValue>12345</premis:linkingAgentIdentifierValue>
+          <premis:linkingAgentIdentifierValue>AM qa/1.x SS qa/0x</premis:linkingAgentIdentifierValue>
         </premis:linkingAgentIdentifier>
         <premis:linkingAgentIdentifier>
           <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>
           <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>
         </premis:linkingAgentIdentifier>
       </premis:event>
-    </mets:xmlData>
-  </mets:mdWrap>
-</mets:digiprovMD>
+    </mets:xmlData> shortened by a line </mets:mdWrap> shortened by a line </mets:digiprovMD>
 
 <mets:digiprovMD ID="digiprovMD_11">
   <mets:mdWrap MDTYPE="PREMIS:EVENT">

--- a/user-manual/transfer/scripts/rights-mets.xml
+++ b/user-manual/transfer/scripts/rights-mets.xml
@@ -1,10 +1,10 @@
 <mets:rightsMD ID="rightsMD_1">
   <mets:mdWrap MDTYPE="PREMIS:RIGHTS">
     <mets:xmlData>
-      <premis:rightsStatement xmlns:premis="info:lc/xmlns/premis-v2" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd">
+      <premis:rightsStatement xmlns:premis="http://www.loc.gov/premis/v3" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd">
         <premis:rightsStatementIdentifier>
           <premis:rightsStatementIdentifierType>UUID</premis:rightsStatementIdentifierType>
-          <premis:rightsStatementIdentifierValue>acfb8ae7-249e-4ff9-a5da-040c8160a856</premis:rightsStatementIdentifierValue>
+          <premis:rightsStatementIdentifierValue>6004a8d8-9d65-4eba-b7c1-b3e38a6d3a5e</premis:rightsStatementIdentifierValue>
         </premis:rightsStatementIdentifier>
         <premis:rightsBasis>License</premis:rightsBasis>
         <premis:licenseInformation>
@@ -24,96 +24,97 @@
           <premis:act>allow</premis:act>
           <premis:restriction>Conditional</premis:restriction>
           <premis:termOfRestriction>
+            <premis:startDate></premis:startDate>
             <premis:endDate>2000-09-00</premis:endDate>
           </premis:termOfRestriction>
           <premis:rightsGrantedNote>Grant note</premis:rightsGrantedNote>
         </premis:rightsGranted>
         <premis:linkingObjectIdentifier>
           <premis:linkingObjectIdentifierType>UUID</premis:linkingObjectIdentifierType>
-          <premis:linkingObjectIdentifierValue>00367530-3d6f-4b9c-8ce7-13c7662a7a87</premis:linkingObjectIdentifierValue>
+          <premis:linkingObjectIdentifierValue>4fe104da-bb8d-4695-a90f-9b8e456bd1b5</premis:linkingObjectIdentifierValue>
         </premis:linkingObjectIdentifier>
       </premis:rightsStatement>
     </mets:xmlData>
   </mets:mdWrap>
-</mets:rightsMD>
-<mets:rightsMD ID="rightsMD_2">
-  <mets:mdWrap MDTYPE="PREMIS:RIGHTS">
-    <mets:xmlData>
-      <premis:rightsStatement xmlns:premis="info:lc/xmlns/premis-v2" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd">
-        <premis:rightsStatementIdentifier>
-          <premis:rightsStatementIdentifierType>UUID</premis:rightsStatementIdentifierType>
-          <premis:rightsStatementIdentifierValue>4ea7a41b-fbff-414b-aad0-c10aa471c147</premis:rightsStatementIdentifierValue>
-        </premis:rightsStatementIdentifier>
-        <premis:rightsBasis>Copyright</premis:rightsBasis>
-        <premis:copyrightInformation>
-          <premis:copyrightStatus>copyrighted</premis:copyrightStatus>
-          <premis:copyrightJurisdiction>ca</premis:copyrightJurisdiction>
-          <premis:copyrightStatusDeterminationDate>2011-01-01</premis:copyrightStatusDeterminationDate>
-          <premis:copyrightNote>Note about copyright.</premis:copyrightNote>
-          <premis:copyrightDocumentationIdentifier>
-            <premis:copyrightDocumentationIdentifierType>Copyright documentation identifier type.</premis:copyrightDocumentationIdentifierType>
-            <premis:copyrightDocumentationIdentifierValue>Copyright documentation identifier value.</premis:copyrightDocumentationIdentifierValue>
-            <premis:copyrightDocumentationRole>Copyright documentation identifier role.</premis:copyrightDocumentationRole>
-          </premis:copyrightDocumentationIdentifier>
-          <premis:copyrightApplicableDates>
-            <premis:startDate>2011-01-01</premis:startDate>
-            <premis:endDate>2013-12-31</premis:endDate>
-          </premis:copyrightApplicableDates>
-        </premis:copyrightInformation>
-        <premis:rightsGranted>
-          <premis:act>disseminate</premis:act>
-          <premis:restriction>Disallow</premis:restriction>
-          <premis:termOfRestriction>
-            <premis:startDate>2011-01-01</premis:startDate>
-            <premis:endDate>2013-12-31</premis:endDate>
-          </premis:termOfRestriction>
-          <premis:rightsGrantedNote>Grant note</premis:rightsGrantedNote>
-        </premis:rightsGranted>
-        <premis:linkingObjectIdentifier>
-          <premis:linkingObjectIdentifierType>UUID</premis:linkingObjectIdentifierType>
-          <premis:linkingObjectIdentifierValue>ef3517aa-8480-4a1f-9b3d-627c25561b12</premis:linkingObjectIdentifierValue>
-        </premis:linkingObjectIdentifier>
-      </premis:rightsStatement>
-    </mets:xmlData>
-  </mets:mdWrap>
-</mets:rightsMD>
-<mets:rightsMD ID="rightsMD_3">
-  <mets:mdWrap MDTYPE="PREMIS:RIGHTS">
-    <mets:xmlData>
-      <premis:rightsStatement xmlns:premis="info:lc/xmlns/premis-v2" xsi:schemaLocation="info:lc/xmlns/premis-v2 http://www.loc.gov/standards/premis/v2/premis-v2-2.xsd">
-        <premis:rightsStatementIdentifier>
-          <premis:rightsStatementIdentifierType>UUID</premis:rightsStatementIdentifierType>
-          <premis:rightsStatementIdentifierValue>049f1b41-d547-43a0-9130-087d0d6f9421</premis:rightsStatementIdentifierValue>
-        </premis:rightsStatementIdentifier>
-        <premis:rightsBasis>Copyright</premis:rightsBasis>
-        <premis:copyrightInformation>
-          <premis:copyrightStatus>copyrighted</premis:copyrightStatus>
-          <premis:copyrightJurisdiction>ca</premis:copyrightJurisdiction>
-          <premis:copyrightStatusDeterminationDate>2011-01-01</premis:copyrightStatusDeterminationDate>
-          <premis:copyrightNote>Note about copyright.</premis:copyrightNote>
-          <premis:copyrightDocumentationIdentifier>
-            <premis:copyrightDocumentationIdentifierType>Copyright documentation identifier type.</premis:copyrightDocumentationIdentifierType>
-            <premis:copyrightDocumentationIdentifierValue>Copyright documentation identifier value.</premis:copyrightDocumentationIdentifierValue>
-            <premis:copyrightDocumentationRole>Copyright documentation identifier role.</premis:copyrightDocumentationRole>
-          </premis:copyrightDocumentationIdentifier>
-          <premis:copyrightApplicableDates>
-            <premis:startDate>2011-01-01</premis:startDate>
-            <premis:endDate>2013-12-31</premis:endDate>
-          </premis:copyrightApplicableDates>
-        </premis:copyrightInformation>
-        <premis:rightsGranted>
-          <premis:act>use</premis:act>
-          <premis:restriction>Disallow</premis:restriction>
-          <premis:termOfRestriction>
-            <premis:startDate>2011-01-01</premis:startDate>
-            <premis:endDate>2013-12-31</premis:endDate>
-          </premis:termOfRestriction>
-          <premis:rightsGrantedNote>Grant note</premis:rightsGrantedNote>
-        </premis:rightsGranted>
-        <premis:linkingObjectIdentifier>
-          <premis:linkingObjectIdentifierType>UUID</premis:linkingObjectIdentifierType>
-          <premis:linkingObjectIdentifierValue>ef3517aa-8480-4a1f-9b3d-627c25561b12</premis:linkingObjectIdentifierValue>
-        </premis:linkingObjectIdentifier>
-      </premis:rightsStatement>
-    </mets:xmlData>
-  </mets:mdWrap>
+  <mets:rightsMD ID="rightsMD_2">
+    <mets:mdWrap MDTYPE="PREMIS:RIGHTS">
+      <mets:xmlData>
+        <premis:rightsStatement xmlns:premis="http://www.loc.gov/premis/v3" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd">
+          <premis:rightsStatementIdentifier>
+            <premis:rightsStatementIdentifierType>UUID</premis:rightsStatementIdentifierType>
+            <premis:rightsStatementIdentifierValue>21c75354-7d35-43f3-9268-b4b2c15da565</premis:rightsStatementIdentifierValue>
+          </premis:rightsStatementIdentifier>
+          <premis:rightsBasis>Copyright</premis:rightsBasis>
+          <premis:copyrightInformation>
+            <premis:copyrightStatus>copyrighted</premis:copyrightStatus>
+            <premis:copyrightJurisdiction>ca</premis:copyrightJurisdiction>
+            <premis:copyrightStatusDeterminationDate>2011-01-01</premis:copyrightStatusDeterminationDate>
+            <premis:copyrightNote>Note about copyright.</premis:copyrightNote>
+            <premis:copyrightDocumentationIdentifier>
+              <premis:copyrightDocumentationIdentifierType>Copyright documentation identifier type.</premis:copyrightDocumentationIdentifierType>
+              <premis:copyrightDocumentationIdentifierValue>Copyright documentation identifier value.</premis:copyrightDocumentationIdentifierValue>
+              <premis:copyrightDocumentationRole>Copyright documentation identifier role.</premis:copyrightDocumentationRole>
+            </premis:copyrightDocumentationIdentifier>
+            <premis:copyrightApplicableDates>
+              <premis:startDate>2011-01-01</premis:startDate>
+              <premis:endDate>2013-12-31</premis:endDate>
+            </premis:copyrightApplicableDates>
+          </premis:copyrightInformation>
+          <premis:rightsGranted>
+            <premis:act>disseminate</premis:act>
+            <premis:restriction>Disallow</premis:restriction>
+            <premis:termOfRestriction>
+              <premis:startDate>2011-01-01</premis:startDate>
+              <premis:endDate>2013-12-31</premis:endDate>
+            </premis:termOfRestriction>
+            <premis:rightsGrantedNote>Grant note</premis:rightsGrantedNote>
+          </premis:rightsGranted>
+          <premis:linkingObjectIdentifier>
+            <premis:linkingObjectIdentifierType>UUID</premis:linkingObjectIdentifierType>
+            <premis:linkingObjectIdentifierValue>f4e314f0-6b0c-4cca-a4e0-ecc5f894488e</premis:linkingObjectIdentifierValue>
+          </premis:linkingObjectIdentifier>
+        </premis:rightsStatement>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:rightsMD>
+  <mets:rightsMD ID="rightsMD_3">
+    <mets:mdWrap MDTYPE="PREMIS:RIGHTS">
+      <mets:xmlData>
+        <premis:rightsStatement xmlns:premis="http://www.loc.gov/premis/v3" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd">
+          <premis:rightsStatementIdentifier>
+            <premis:rightsStatementIdentifierType>UUID</premis:rightsStatementIdentifierType>
+            <premis:rightsStatementIdentifierValue>b365f1ab-f8d1-4fde-92f0-15197dc6fd8c</premis:rightsStatementIdentifierValue>
+          </premis:rightsStatementIdentifier>
+          <premis:rightsBasis>Copyright</premis:rightsBasis>
+          <premis:copyrightInformation>
+            <premis:copyrightStatus>copyrighted</premis:copyrightStatus>
+            <premis:copyrightJurisdiction>ca</premis:copyrightJurisdiction>
+            <premis:copyrightStatusDeterminationDate>2011-01-01</premis:copyrightStatusDeterminationDate>
+            <premis:copyrightNote>Note about copyright.</premis:copyrightNote>
+            <premis:copyrightDocumentationIdentifier>
+              <premis:copyrightDocumentationIdentifierType>Copyright documentation identifier type.</premis:copyrightDocumentationIdentifierType>
+              <premis:copyrightDocumentationIdentifierValue>Copyright documentation identifier value.</premis:copyrightDocumentationIdentifierValue>
+              <premis:copyrightDocumentationRole>Copyright documentation identifier role.</premis:copyrightDocumentationRole>
+            </premis:copyrightDocumentationIdentifier>
+            <premis:copyrightApplicableDates>
+              <premis:startDate>2011-01-01</premis:startDate>
+              <premis:endDate>2013-12-31</premis:endDate>
+            </premis:copyrightApplicableDates>
+          </premis:copyrightInformation>
+          <premis:rightsGranted>
+            <premis:act>use</premis:act>
+            <premis:restriction>Disallow</premis:restriction>
+            <premis:termOfRestriction>
+              <premis:startDate>2011-01-01</premis:startDate>
+              <premis:endDate>2013-12-31</premis:endDate>
+            </premis:termOfRestriction>
+            <premis:rightsGrantedNote>Grant note</premis:rightsGrantedNote>
+          </premis:rightsGranted>
+          <premis:linkingObjectIdentifier>
+            <premis:linkingObjectIdentifierType>UUID</premis:linkingObjectIdentifierType>
+            <premis:linkingObjectIdentifierValue>f4e314f0-6b0c-4cca-a4e0-ecc5f894488e</premis:linkingObjectIdentifierValue>
+          </premis:linkingObjectIdentifier>
+        </premis:rightsStatement>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:rightsMD>


### PR DESCRIPTION
I did not find any METS schema changes that were required, but some PREMIS Events and Rights metadata needed to be updated to version 3 from previous versions.

This is linked to issue: https://github.com/archivematica/Issues/issues/949