### PR TITLE
fix typo in rebuild index example comment

### DIFF
--- a/admin-manual/maintenance/maintenance.rst
+++ b/admin-manual/maintenance/maintenance.rst
@@ -140,7 +140,7 @@ the path of the AIP storage location you confirmed above.
        cd /usr/share/archivematica/dashboard
        /usr/share/archivematica/virtualenvs/archivematica/bin/python \
            manage.py rebuild_elasticsearch_aip_index_from_files \
-               /var/archivematica/sharedDirectory/www/AIPsStoree --delete-all
+               /var/archivematica/sharedDirectory/www/AIPsStore --delete-all
    ";
 
 The command accepts the following parameters:


### PR DESCRIPTION
default path for aipstore had an extra 'e' in it.