### PR TITLE
add DIP Dublin Core to AtoM fields mapping

### DIFF
--- a/user-manual/access/access.rst
+++ b/user-manual/access/access.rst
@@ -84,7 +84,9 @@ recognize by :ref:`using the arrangement feature on Appraisal tab
 
 You can also :ref:`add descriptive metadata <add-metadata>` to your transfer
 using either the metadata form or the metadata CSV file. This descriptive
-metadata will be passed to AtoM. Note that the AtoM DIP upload integration supports Dublin Core descriptive metadata only. The following Dublin Core fields are mapped to the ISAD(G) template in AtoM:
+metadata will be passed to AtoM. Note that the AtoM DIP upload integration
+supports Dublin Core descriptive metadata only. The following Dublin Core
+fields are mapped to the ISAD(G) template in AtoM:
 
 ===========  ===========================================
 Dublin Core  ISAD(G)

--- a/user-manual/access/access.rst
+++ b/user-manual/access/access.rst
@@ -84,8 +84,26 @@ recognize by :ref:`using the arrangement feature on Appraisal tab
 
 You can also :ref:`add descriptive metadata <add-metadata>` to your transfer
 using either the metadata form or the metadata CSV file. This descriptive
-metadata will be passed to AtoM. Note that the AtoM DIP upload integration
-supports Dublin Core descriptive metadata only.
+metadata will be passed to AtoM. Note that the AtoM DIP upload integration supports Dublin Core descriptive metadata only. The following Dublin Core fields are mapped to the ISAD(G) template in AtoM:
+
+===========  ===========================================
+Dublin Core  ISAD(G)
+===========  ===========================================
+title        title  
+identifier   identifier
+creator      name of creator
+date         date of creation
+type         subject access point
+provenance   immediate source of acquisition or transfer
+description  scope and content
+extent       extent and medium
+format       extent and medium
+source       location of originals
+language     language of material
+rights       conditions governing access
+coverage     place access point
+subject      subject access point
+===========  ===========================================
 
 .. note::
 


### PR DESCRIPTION
When AtoM receives a DIP upload from Archivematica it will look for Dublin Core metadata to populate archival description records. This documentation update adds a table that show how AtoM maps Dublin Core metadata to its fields, as per the source code here: https://github.com/artefactual/atom/blob/qa/2.x/lib/QubitMetsParser.class.php#L278-L366

Closes issue #414