### PR TITLE
Typo in Documentation for Shib Dashboard Variable

### DIFF
--- a/admin-manual/security/security.rst
+++ b/admin-manual/security/security.rst
@@ -180,7 +180,7 @@ Shibboleth backend configuration in Archivematica Dashboard
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 #. Enable the authentication backend using the environment variable
-   ``SS_SHIBBOLETH_AUTHENTICATION``. You can find more details about this
+   ``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SHIBBOLETH_AUTHENTICATION``. You can find more details about this
    environment string in the `configuration document <am-dashboard-config_>`_.
 
 #. Customize the ``shibboleth_auth.py`` settings module as needed.

--- a/locale/es/LC_MESSAGES/admin-manual/security/security.po
+++ b/locale/es/LC_MESSAGES/admin-manual/security/security.po
@@ -216,7 +216,7 @@ msgstr ""
 #: ../../admin-manual/security/security.rst:149
 msgid ""
 "Enable the authentication backend using the environment variable "
-"``SS_SHIBBOLETH_AUTHENTICATION``. You can find more details about this "
+"``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SHIBBOLETH_AUTHENTICATION``. You can find more details about this "
 "environment string in the `configuration document <am-dashboard-"
 "config_>`_."
 msgstr ""

--- a/locale/fr/LC_MESSAGES/admin-manual/security/security.po
+++ b/locale/fr/LC_MESSAGES/admin-manual/security/security.po
@@ -224,7 +224,7 @@ msgstr ""
 #: ../../admin-manual/security/security.rst:149
 msgid ""
 "Enable the authentication backend using the environment variable "
-"``SS_SHIBBOLETH_AUTHENTICATION``. You can find more details about this "
+"``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SHIBBOLETH_AUTHENTICATION``. You can find more details about this "
 "environment string in the `configuration document <am-dashboard-config_>`_."
 msgstr ""
 

--- a/locale/pt_BR/LC_MESSAGES/admin-manual/security/security.po
+++ b/locale/pt_BR/LC_MESSAGES/admin-manual/security/security.po
@@ -280,11 +280,11 @@ msgstr "Configuração de backend do Shibboleth no Archivematica Dashboard"
 #: ../../admin-manual/security/security.rst:149
 msgid ""
 "Enable the authentication backend using the environment variable "
-"``SS_SHIBBOLETH_AUTHENTICATION``. You can find more details about this "
+"``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SHIBBOLETH_AUTHENTICATION``. You can find more details about this "
 "environment string in the `configuration document <am-dashboard-config_>`_."
 msgstr ""
 "Ativar o backend de autenticação usando a variável de "
-"ambiente``SS_SHIBBOLETH_AUTHENTICATION``. Você pode encontrar mais detalhes "
+"ambiente``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SHIBBOLETH_AUTHENTICATION``. Você pode encontrar mais detalhes "
 "sobre este srting de ambiente no `documento de configuração <am-dashboard-"
 "config_>`_."
 


### PR DESCRIPTION
It should be ``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SHIBBOLETH_AUTHENTICATION`` and not ``SS_SHIBBOLETH_AUTHENTICATION`` for the dashboard

https://github.com/artefactual/archivematica/blob/56388245da256fb8f5a5871874fac2f7a7c5d8e0/src/dashboard/install/README.md?plain=1#L193