### PR TITLE
Update typo in DSpace Documentation

### DIFF
--- a/user-manual/transfer/dspace.rst
+++ b/user-manual/transfer/dspace.rst
@@ -14,7 +14,7 @@ Archivematica pipeline can access.
 
 * :ref:`DSpace version compatibility <dspace-version>`
 * :ref:`DSpace export structure <dspace-export-structure>`
-* :ref:`Processing Dataverse datasets <processing-dspace-exports>`
+* :ref:`Processing DSpace exports <processing-dspace-exports>`
 
 .. _dspace-version:
 


### PR DESCRIPTION
Documentation was referencing Dataverse in the text for the url but is actually for DSpace.