### PR TITLE
Update manual install instructions for Ubuntu

### DIFF
--- a/admin-manual/installation-setup/installation/install-ubuntu.rst
+++ b/admin-manual/installation-setup/installation/install-ubuntu.rst
@@ -61,17 +61,23 @@ Ubuntu 18.04 (Bionic) installation instructions
       :language: bash
       :lines: 27
 
+#. Create the Storage Service database and set up the expected credentials.
+
+   .. literalinclude:: scripts/am-bionic-deb.sh
+      :language: bash
+      :lines: 29-31
+
 #. Install the Storage Service package.
 
    .. literalinclude:: scripts/am-bionic-deb.sh
        :language: bash
-       :lines: 29
+       :lines: 33
 
 #. Configure the Storage Service.
 
    .. literalinclude:: scripts/am-bionic-deb.sh
       :language: bash
-      :lines: 31-32
+      :lines: 35-36
 
 #. Install the Archivematica packages. The order of installation is important -
    the archivematica-mcp-server package must be installed before the dashboard
@@ -79,17 +85,13 @@ Ubuntu 18.04 (Bionic) installation instructions
    on a separate machine, that configuration is not documented in these
    instructions.
 
-   The archivematica-mcp-server package will install MySQL and configure the
-   database used by Archivematica. Depending on the version of MySQL that is
-   installed, the interfaces that you see may differ slightly.
-
    When you are prompted to create a password for the archivematica-mcp-server,
    you must use ``demo`` as the password during the install process. The
    password can be changed after the installation is complete.
 
    .. literalinclude:: scripts/am-bionic-deb.sh
       :language: bash
-      :lines: 34-36
+      :lines: 38-40
 
 #.  Configure the Archivematica components (optional). There are a number of
     environment variables that Archivematica recognizes which can be used to
@@ -112,7 +114,7 @@ Ubuntu 18.04 (Bionic) installation instructions
 
     .. literalinclude:: scripts/am-bionic-deb.sh
        :language: bash
-       :lines: 38
+       :lines: 42
 
 #. Start Elasticsearch (optional).
 
@@ -121,13 +123,13 @@ Ubuntu 18.04 (Bionic) installation instructions
 
     .. literalinclude:: scripts/am-bionic-deb.sh
       :language: bash
-      :lines: 40-42
+      :lines: 44-46
 
 #. Start the remaining services
 
     .. literalinclude:: scripts/am-bionic-deb.sh
        :language: bash
-       :lines: 44-54
+       :lines: 48-58
 
     If you have trouble with the gearman or clamav command try restarting it:
 
@@ -151,7 +153,7 @@ Ubuntu 18.04 (Bionic) installation instructions
 
     .. literalinclude:: scripts/am-bionic-deb.sh
        :language: bash
-       :lines: 56-59
+       :lines: 60-63
 
 #. Complete :ref:`Post Install Configuration <ubuntu-post-install-config>`.
 

--- a/admin-manual/installation-setup/installation/scripts/am-bionic-deb.sh
+++ b/admin-manual/installation-setup/installation/scripts/am-bionic-deb.sh
@@ -23,8 +23,12 @@ echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee 
 sudo apt-get update
 sudo apt-get -y upgrade
 
-sudo apt-get install -y htop ntp apt-transport-https unzip openjdk-8-jre-headless
+sudo apt-get install -y htop ntp apt-transport-https unzip openjdk-8-jre-headless mysql-server libmysqlclient-dev
 sudo apt-get install -y elasticsearch
+
+sudo -H -u root mysql -hlocalhost -uroot -e "DROP DATABASE IF EXISTS SS; CREATE DATABASE SS CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
+sudo -H -u root mysql -hlocalhost -uroot -e "CREATE USER 'archivematica'@'localhost' IDENTIFIED BY 'demo';"
+sudo -H -u root mysql -hlocalhost -uroot -e "GRANT ALL ON SS.* TO 'archivematica'@'localhost';"
 
 sudo apt-get install -y archivematica-storage-service
 


### PR DESCRIPTION
As is, the install fails due to the missing MySQL Server.
Steps were updated according to the CentOS install guide and actual behavior during install.