### PR TITLE
suggestion: shorter instructions with active voice for clarity

### DIFF
--- a/dev-manual/api/api-overview.rst
+++ b/dev-manual/api/api-overview.rst
@@ -90,7 +90,7 @@ To generate an API key for an existing user in Archivematica:
 2. Select the username of the user for whom you want to generate an API key.
 3. Click on the **Regenerate API key** box.
 4. Click **Save**.
-5. Access the new API key on the user’s profile by clicking on their username.
+5. Access the new API key on the user's profile by clicking on their username.
 
 .. note::
    In the Storage Service, an API key is automatically generated for each new

--- a/dev-manual/api/api-overview.rst
+++ b/dev-manual/api/api-overview.rst
@@ -86,15 +86,11 @@ generate an API key for any user account in the database.
 
 To generate an API key for an existing user in Archivematica:
 
-1. Navigate to **Admin > Users**, and then you will be redirected to the
-   Users page.
-2. Select the user for whom you would like to generate an API key, and click
-   their username or the **Edit** button. Archivematica will load the user’s
-   Profile page.
-3. Click to enable the **Regenerate API key** box.
-4. Then click **Save**.
-5. In the **Users** page, click the username again to return to that user's
-   profile, and then you will see the regenerated API key.
+1. Navigate to **Admin > Users** to access the Users page.
+2. Select the username of the user for whom you want to generate an API key.
+3. Click on the **Regenerate API key** box.
+4. Click **Save**.
+5. Access the new API key on the user’s profile by clicking on their username.
 
 .. note::
    In the Storage Service, an API key is automatically generated for each new


### PR DESCRIPTION
Hello! :sparkles: 

For the next version of Archivematica, here is one tiny rewrite for the instructions on how to reset an API key in the admin panel.

My goal was to shorten the instructions and to make them more actionable by using the [active voice](https://developers.google.com/tech-writing/one/active-voice#distinguish_active_voice_from_passive_voice_in_more_complex_sentences).

