### PR TITLE
Update sample installation scripts

### DIFF
--- a/admin-manual/installation-setup/installation/install-rocky.rst
+++ b/admin-manual/installation-setup/installation/install-rocky.rst
@@ -192,7 +192,7 @@ Installation instructions
 
    .. literalinclude:: scripts/am-rocky-rpm.sh
       :language: bash
-      :lines: 110-112
+      :lines: 112-114
 
 #. Complete :ref:`Post Install Configuration <rocky-post-install-config>`.
 

--- a/admin-manual/installation-setup/installation/install-ubuntu.rst
+++ b/admin-manual/installation-setup/installation/install-ubuntu.rst
@@ -134,7 +134,7 @@ Ubuntu 22.04 (Jammy) installation instructions
 
     .. literalinclude:: scripts/am-jammy-deb.sh
        :language: bash
-       :lines: 45-54
+       :lines: 45-55
 
     If you have trouble with the gearman or clamav command try restarting it:
 
@@ -158,7 +158,7 @@ Ubuntu 22.04 (Jammy) installation instructions
 
     .. literalinclude:: scripts/am-jammy-deb.sh
        :language: bash
-       :lines: 56-59
+       :lines: 57-60
 
 #. Complete :ref:`Post Install Configuration <ubuntu-post-install-config>`.
 

--- a/admin-manual/installation-setup/installation/scripts/am-jammy-deb.sh
+++ b/admin-manual/installation-setup/installation/scripts/am-jammy-deb.sh
@@ -43,6 +43,7 @@ sudo service elasticsearch restart
 sudo systemctl enable elasticsearch
 
 sudo service clamav-freshclam restart
+sleep 120s
 sudo service clamav-daemon start
 sudo service gearman-job-server restart
 sudo service archivematica-mcp-server start

--- a/admin-manual/installation-setup/installation/scripts/am-jammy-deb.sh
+++ b/admin-manual/installation-setup/installation/scripts/am-jammy-deb.sh
@@ -71,3 +71,22 @@ sudo -u archivematica bash -c " \
           --api-key="THIS_IS_THE_SS_APIKEY" \
           --superuser
 ";
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-dashboard || \
+        source /etc/sysconfig/archivematica-dashboard \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/share/archivematica/dashboard
+      /usr/share/archivematica/virtualenvs/archivematica/bin/python manage.py install \
+          --username="admin" \
+          --password="archivematica" \
+          --email="example@example.com" \
+          --org-name="test" \
+          --org-id="test" \
+          --api-key="THIS_IS_THE_SS_APIKEY" \
+          --ss-url="http://localhost:8000" \
+          --ss-user="admin" \
+          --ss-api-key="THIS_IS_THE_SS_APIKEY" \
+          --site-url="http://localhost"
+";

--- a/admin-manual/installation-setup/installation/scripts/am-rocky-rpm.sh
+++ b/admin-manual/installation-setup/installation/scripts/am-rocky-rpm.sh
@@ -107,6 +107,9 @@ sudo -u root systemctl start clamd@scan
 sudo -u root systemctl restart archivematica-dashboard
 sudo -u root systemctl restart archivematica-mcp-server
 
+sudo -u root yum install -y firewalld
+sudo -u root systemctl start firewalld
+
 sudo firewall-cmd --add-port=81/tcp --permanent
 sudo firewall-cmd --add-port=8001/tcp --permanent
 sudo firewall-cmd --reload

--- a/admin-manual/installation-setup/installation/scripts/am-rocky-rpm.sh
+++ b/admin-manual/installation-setup/installation/scripts/am-rocky-rpm.sh
@@ -127,3 +127,22 @@ sudo -u archivematica bash -c " \
           --api-key="THIS_IS_THE_SS_APIKEY" \
           --superuser
 ";
+
+sudo -u archivematica bash -c " \
+    set -a -e -x
+    source /etc/default/archivematica-dashboard || \
+        source /etc/sysconfig/archivematica-dashboard \
+            || (echo 'Environment file not found'; exit 1)
+    cd /usr/share/archivematica/dashboard
+      /usr/share/archivematica/virtualenvs/archivematica/bin/python manage.py install \
+          --username="test" \
+          --password="test" \
+          --email="example@example.com" \
+          --org-name="test" \
+          --org-id="test" \
+          --api-key="THIS_IS_THE_SS_APIKEY" \
+          --ss-url="http://localhost4:7500" \
+          --ss-user="test" \
+          --ss-api-key="THIS_IS_THE_SS_APIKEY" \
+          --site-url="http://localhost:81"
+";


### PR DESCRIPTION
This install and enables the `firewalld` package in the Rocky 9 sample script to avoid this error:

```
+ sudo firewall-cmd --add-port=81/tcp --permanent
sudo: firewall-cmd: command not found
```

It also restores [waiting for the `clamav-freshclam`](https://github.com/artefactual/archivematica-docs/blob/9ba99dec2082a408e177799a4955c3d1c4339d2b/admin-manual/installation-setup/installation/scripts/am-bionic-deb.sh#L49) in the Ubuntu Jammy sample script to avoid an error in the `clamav-daemon` service.

Finally it sets up an Archivematica pipeline at the end of the script runs. This doesn't affect the documentation output, but makes testing installations with the scripts easier.