### PR TITLE
Fix a few github url to match the pattern described in the linkcheck configuration

### DIFF
--- a/admin-manual/installation-setup/customization/antivirus-admin.rst
+++ b/admin-manual/installation-setup/customization/antivirus-admin.rst
@@ -159,5 +159,5 @@ environment itself.
 .. _ClamAV manual pages: https://manpages.debian.org/jessie/clamav-daemon/clamd.conf.5.en.html
 .. _Compose .yml file: https://github.com/artefactual/archivematica/blob/qa/1.x/hack/docker-compose.yml
 .. _configuration file: https://github.com/artefactual-labs/ansible-clamav/blob/master/defaults/main.yml
-.. _Ansible environment variables: https://github.com/artefactual-labs/ansible-archivematica-src/blob/stable/1.15.x/README.md#environment-variables
+.. _Ansible environment variables: https://github.com/artefactual-labs/ansible-archivematica-src/blob/d4474c3dbaef2b561c87e0650c6ee386be6910a7/README.md#environment-variables
 .. _Bug 11958: https://bugzilla.clamav.net/show_bug.cgi?id=11958

--- a/admin-manual/installation-setup/customization/scaling-archivematica.rst
+++ b/admin-manual/installation-setup/customization/scaling-archivematica.rst
@@ -424,7 +424,7 @@ to create (and check) than the alternatives (e.g. SHA-256).
 
 .. _MCPServer: https://github.com/artefactual/archivematica/tree/6ead2083f7bdd8b10ca76d41a7bff9c5aee23eb3/src/MCPServer/install
 .. _MCPClient: https://github.com/artefactual/archivematica/tree/6ead2083f7bdd8b10ca76d41a7bff9c5aee23eb3/src/MCPClient
-.. _MCPClient concurrency: https://github.com/artefactual/archivematica/tree/3e52494735ebfeb0cabc477d95d692034f4b3142/src/MCPClient#concurrency
+.. _MCPClient concurrency: https://github.com/artefactual/archivematica/blob/3e52494735ebfeb0cabc477d95d692034f4b3142/src/MCPClient/README.md#concurrency
 .. _systemd: https://en.wikipedia.org/wiki/Systemd
 .. _unit file: https://www.freedesktop.org/software/systemd/man/systemd.unit.html
 .. _MCPClient unit file: https://raw.githubusercontent.com/artefactual-labs/am-packbuild/qa/1.x/rpm-EL9/archivematica/etc/archivematica-mcp-client.service

--- a/admin-manual/installation-setup/installation/install-advanced.rst
+++ b/admin-manual/installation-setup/installation/install-advanced.rst
@@ -47,7 +47,7 @@ In order to obtain valid SSL certificates trusted by any browser, you can use
 
 :ref:`Back to the top <install-advanced>`
 
-.. _`development environment instructions`: https://github.com/artefactual/archivematica/tree/qa/1.x/hack#archivematica-development-on-docker-compose
+.. _`development environment instructions`: https://github.com/artefactual/archivematica/blob/qa/1.x/hack/README.md
 .. _`sample configurations for the dashboard`: https://github.com/artefactual-labs/ansible-archivematica-src/blob/8b2aee1ba90053d030c31f3b8d0e5b0f14fcf57c/templates/etc/nginx/sites-available/dashboard-ssl.conf.j2
 .. _`sample configurations for the Storage Service`: https://github.com/artefactual-labs/ansible-archivematica-src/blob/8b2aee1ba90053d030c31f3b8d0e5b0f14fcf57c/templates/etc/nginx/sites-available/storage-ssl.conf.j2
 .. _`Let's Encrypt`: https://letsencrypt.org

--- a/admin-manual/installation-setup/installation/install-ansible.rst
+++ b/admin-manual/installation-setup/installation/install-ansible.rst
@@ -146,5 +146,5 @@ steps:
 :ref:`Back to the top <install-ansible>`
 
 .. _`deploy-pub`: https://github.com/artefactual/deploy-pub
-.. _`ansible-archivematica-src`: https://github.com/artefactual-labs/ansible-archivematica-src/tree/d4474c3dbaef2b561c87e0650c6ee386be6910a7#disable-elasticsearch-use
+.. _`ansible-archivematica-src`: https://github.com/artefactual-labs/ansible-archivematica-src/blob/d4474c3dbaef2b561c87e0650c6ee386be6910a7/README.md#disable-elasticsearch-use
 .. _`Vagrant website`: https://www.vagrantup.com/downloads.html

--- a/admin-manual/installation-setup/integrations/binder-setup.rst
+++ b/admin-manual/installation-setup/integrations/binder-setup.rst
@@ -48,5 +48,5 @@ section :ref:`Upload a DIP to Binder <upload-binder>`.
 
 .. _Binder documentation: https://binder.readthedocs.io/en/latest/user-manual/overview/project-status.html
 .. _Binder GitHub repository: https://github.com/artefactual/binder
-.. _installation instructions: https://github.com/artefactual/binder/tree/a2893fe589c67f147de440a52301c4025ad1cd4e#installation
-.. _configuration instructions: https://github.com/artefactual/binder/tree/a2893fe589c67f147de440a52301c4025ad1cd4e#configuration
+.. _installation instructions: https://github.com/artefactual/binder/blob/a2893fe589c67f147de440a52301c4025ad1cd4e/README.md#installation
+.. _configuration instructions: https://github.com/artefactual/binder/blob/a2893fe589c67f147de440a52301c4025ad1cd4e/README.md#configuration

--- a/admin-manual/installation-setup/upgrading/upgrading.rst
+++ b/admin-manual/installation-setup/upgrading/upgrading.rst
@@ -563,4 +563,4 @@ the databases and their tables.
 .. _`Elasticsearch 6.8 docs`: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-snapshots.html
 .. _`release notes`: https://wiki.archivematica.org/Release_Notes
 .. _`Reindex API`: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html
-.. _`es-reindex.sh`: https://github.com/artefactual-labs/ops-helpers/blob/master/es-helpers/README.md#es-reindexsh-update-search-indicess
+.. _`es-reindex.sh`: https://github.com/artefactual-labs/ops-helpers/blob/master/es-helpers/README.md#es-reindexsh-update-search-indices

--- a/admin-manual/installation-setup/upgrading/upgrading.rst
+++ b/admin-manual/installation-setup/upgrading/upgrading.rst
@@ -563,4 +563,4 @@ the databases and their tables.
 .. _`Elasticsearch 6.8 docs`: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-snapshots.html
 .. _`release notes`: https://wiki.archivematica.org/Release_Notes
 .. _`Reindex API`: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html
-.. _`es-reindex.sh`: https://github.com/artefactual-labs/ops-helpers/tree/master/es-helpers#es-reindexsh-update-search-indices
+.. _`es-reindex.sh`: https://github.com/artefactual-labs/ops-helpers/blob/master/es-helpers/README.md#es-reindexsh-update-search-indicess

--- a/user-manual/transfer/import-metadata.rst
+++ b/user-manual/transfer/import-metadata.rst
@@ -281,7 +281,7 @@ This feature is disabled by default. It's still considered experimental and
 its validation rules need to be configured according to the user needs before
 using it.
 
-The `Metadata XML validation variables <https://github.com/artefactual/archivematica/tree/179247f9e5508defd563e4eae3c73ea8e8b674f3/src/MCPClient/install#metadata-xml-validation-variables>`_
+The `Metadata XML validation variables <https://github.com/artefactual/archivematica/blob/179247f9e5508defd563e4eae3c73ea8e8b674f3/src/MCPClient/install/README.md#metadata-xml-validation-variables>`_
 section of the MCPClient installation documentation explains how to enable
 and configure this feature. You can also check the
 `sample configuration files <https://github.com/artefactual/archivematica-sampledata/tree/b01539902198a9e4a15f76add7b6b129eecf6b7b/xml-validation>`_


### PR DESCRIPTION
Part of https://github.com/archivematica/Issues/issues/1638

To fit the pattern described in https://github.com/artefactual/archivematica-docs/pull/440

In other cases, I would have add a pattern to ignore the links that do not refers to .md files - right now I believe that this adds clarity to the URL? I might change my mind on this :sweat_smile: 

