### PR TITLE
Update GitHub link to refer to the file directly

### DIFF
--- a/admin-manual/installation-setup/installation/_csv/install-development.csv
+++ b/admin-manual/installation-setup/installation/_csv/install-development.csv
@@ -1,2 +1,2 @@
 Development environments,,
-"Docker and Linux",`Archivematica development on Docker Compose <https://github.com/artefactual/archivematica/tree/qa/1.x/hack#archivematica-development-on-docker-compose>`_,Docker will provide instructions on how to use it as a non-root user. This may not be desirable for all.
+"Docker and Linux",`Archivematica development on Docker Compose <https://github.com/artefactual/archivematica/blob/qa/1.x/hack/README.md>`_,Docker will provide instructions on how to use it as a non-root user. This may not be desirable for all.


### PR DESCRIPTION
Since the heading is the title, we should refer to the file directly.

This would allow `make linkcheck` to resolve.

As part of https://github.com/archivematica/Issues/issues/1638