### PR TITLE
Improving linkcheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,23 @@ jobs:
       - name: "Run build test"
         run: |
           make test
-      - name: "Linkcheck"
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v24
+      - name: Run linkcheck on .rst files
         run: |
-          make linkcheck
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            if [ "${file: -4}" == ".rst" ]
+              then
+                var="$var $file"
+            fi
+          done
+          if [ -z "$var" ]
+          then
+                echo "No *.rst changed files to check."
+          else
+                make files="$var" linkcheck-specified-files
+          fi
   lint:
     name: "Linting"
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,10 @@ jobs:
       - name: "Run build test"
         run: |
           make test
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v24
-      - name: Run linkcheck on .rst files
+      - name: "Get changed files"
+        id: "changed-files"
+        uses: "tj-actions/changed-files@v24"
+      - name: "Run linkcheck on .rst files"
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             if [ "${file: -4}" == ".rst" ]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -n -q
+SPHINXOPTS    = -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
@@ -187,9 +187,9 @@ changes:
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
-.PHONY: linkcheck
-linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
+.PHONY: linkcheck-specified-files
+linkcheck-specified-files:
+	$(SPHINXBUILD) -q -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR) $(files)
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -n
+SPHINXOPTS    = -n -q
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
Per https://github.com/sphinx-doc/sphinx/issues/8791#issuecomment-1895586426 , adding the `-q` or quiet option flag to the Sphinx options will allow us to only print out errors (broken URLs).

