### PR TITLE
Ignore website for linkcheck

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -374,6 +374,7 @@ linkcheck_ignore = [
     r'([(http:)(https:)]*(\/\/)*(192.168.168.192)(:)*[\d]*)',
     'http://example.archivematica.org',
     'http://myAtoM.ca',
+    'https://scope.com',
     'https://www.transifex.com/artefactual/archivematica/',
     r'([(http:)(https:)]*(\/\/)[\S]*(.)*(github.com)([\s\S])*((.md)[#][\w-]*))',
     # could be removed in future versions (version > 1.15)


### PR DESCRIPTION
Found during https://github.com/artefactual/archivematica-docs/pull/465

I think we can ignore this as I believe we use this URL as an example.com placeholder... Let me know if that is not the case.