### PR TITLE
Enable full search features with HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sphinx-build -D language=pt_BR ./ _build/html/pt_BR # for *português do Brasil*
 * Access the documentation:
 
 ```bash
-python3 -m http.server --d _build/html
+python3 -m http.server -d _build/html
 ```
 
 The HTML files for the documentation will be in

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sphinx-build -D language=pt_BR ./ _build/html/pt_BR # for *português do Brasil*
 * Access the documentation:
 
 ```bash
-open _build/html/index.html
+python3 -m http.server
 ```
 
 The HTML files for the documentation will be in

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ sphinx-build -D language=pt_BR ./ _build/html/pt_BR # for *português do Brasil*
 * Access the documentation:
 
 ```bash
-python3 -m http.server
+python3 -m http.server --d _build/html
 ```
 
 The HTML files for the documentation will be in
 `archivematica-docs/_build/html/`.
 You can open the files in a browser of your choice, without having any access
-to the Internet.
+to the Internet, by accessing `http://localhost:8000`.
 
 While this offline version will not have the Archivematica web theme, you will
 gain access to improved search features.


### PR DESCRIPTION
You will need the server to access full search features, such as highlighting the context surrounding keywords you are looking for.