### PR TITLE
Inline code: fix

### DIFF
--- a/admin-manual/installation-setup/installation/install-rocky.rst
+++ b/admin-manual/installation-setup/installation/install-rocky.rst
@@ -170,7 +170,7 @@ Installation instructions
    **Configuration**
 
    Each service has a configuration file in
-   /etc/sysconfig/archivematica-packagename
+   `/etc/sysconfig/archivematica-packagename`
 
    **Troubleshooting**
 


### PR DESCRIPTION
Relates to https://github.com/artefactual/archivematica-docs/pull/461

We want to ignore this because it is code, not because we told the spellchecker to ignore it.