### PR TITLE
Document v2beta package endpoint behavior

### DIFF
--- a/dev-manual/api/api-reference-archivematica.rst
+++ b/dev-manual/api/api-reference-archivematica.rst
@@ -861,8 +861,11 @@ Examples:
 
 Only a subset of these options might be needed for most use-cases. A fundamental
 difference between the package endpoint and others from which a transfer can be
-initiated is that a storage service transfer location UUID isnt always required.
-In some cases that might still be ideal.
+initiated is that a storage service transfer source location's UUID isn't always
+required and the default transfer source location is used automatically.
+
+When working with multiple transfer source locations, to start a transfer from a
+non-default location, you need to specify the location's UUID.
 
 *Starting a transfer using an absolute path*::
 


### PR DESCRIPTION
It states what the endpoint does when the transfer source location's UUID is not explicitly passed and how to use it when multiple locations are available.

Connected to the first point of https://github.com/archivematica/Issues/issues/1709#issuecomment-2294186837