### PR TITLE
Fix Ubuntu package upgrade instructions

### DIFF
--- a/admin-manual/installation-setup/upgrading/upgrading.rst
+++ b/admin-manual/installation-setup/upgrading/upgrading.rst
@@ -133,8 +133,10 @@ Upgrade on Ubuntu packages
 
    .. code:: bash
 
-      echo 'deb [arch=amd64] http://packages.archivematica.org/1.18.x/ubuntu jammy main' >> /etc/apt/sources.list
-      echo 'deb [arch=amd64] http://packages.archivematica.org/1.18.x/ubuntu-externals jammy main' >> /etc/apt/sources.list
+      curl -fsSL https://packages.archivematica.org/1.18.x/key.asc | sudo gpg --dearmor -o /etc/apt/keyrings/archivematica-1.18.x.gpg
+
+      echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/archivematica-1.18.x.gpg] http://packages.archivematica.org/1.18.x/ubuntu jammy main' >> /etc/apt/sources.list
+      echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/archivematica-1.18.x.gpg] http://packages.archivematica.org/1.18.x/ubuntu-externals jammy main' >> /etc/apt/sources.list
 
    Optionally you can remove the lines referencing
    packages.archivematica.org/|previous_version|.x from /etc/apt/sources.list.
@@ -154,11 +156,10 @@ Upgrade on Ubuntu packages
 
    .. code:: bash
 
-      sudo apt-get install archivematica-common
+      sudo apt-get install archivematica archivematica-common
       sudo apt-get install archivematica-dashboard
       sudo apt-get install archivematica-mcp-server
       sudo apt-get install archivematica-mcp-client
-      sudo apt-get install archivematica
 
 #. Restart services.
 


### PR DESCRIPTION
This extends the "Upgrade on Ubuntu packages" section to cover adding the 1.18.x signing key and installing the`archivematica` meta package (which supplies the source tree) before the individual component packages.

Connected to https://github.com/archivematica/Issues/issues/1769