### PR TITLE
Document new cookie and session security variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: "https://github.com/sphinx-contrib/sphinx-lint"
-  rev: "v1.0.1"
+  rev: "v1.0.2"
   hooks:
   - id: "sphinx-lint"
 - repo: "https://github.com/igorshubovych/markdownlint-cli"
-  rev: "v0.45.0"
+  rev: "v0.46.0"
   hooks:
   - id: "markdownlint"
     exclude: |

--- a/admin-manual/security/security.rst
+++ b/admin-manual/security/security.rst
@@ -321,21 +321,83 @@ Cookie and session security
 
 Starting with Archivematica 1.18.0 and Storage Service 0.24.0, the Dashboard and
 the Storage Service ship with stricter defaults for cookie attributes (Secure,
-HttpOnly, SameSite). Secure-related settings (for example, ``*_SESSION_COOKIE_SECURE``
-and ``*_CSRF_COOKIE_SECURE``) are now enabled by default.
+HttpOnly, SameSite) suited for deployments using HTTPS.
 
-See `Cookie configuration improvements <cookie-configuration-improvements_>`_ in
-the Archivematica 1.18.0 release notes for the full list of environment
-variables and guidance on adjusting the defaults for your deployment.
+Administrators should review their settings to take advantage of these options
+ensuring deployment configurations are updated to align with these stricter
+defaults.
+
+Dashboard application variables
+===============================
+
+============================================================= ============== ==========
+Variable Name                                                 Previous Value New Value
+============================================================= ============== ==========
+``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SECURE``   ``false``      ``true``
+``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_HTTPONLY`` ``false``      ``true``
+``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SAMESITE`` ``Lax``        ``Strict``
+``ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSRF_COOKIE_SECURE``      ``false``      ``true``
+``ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSRF_COOKIE_HTTPONLY``    ``false``      ``false``
+``ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSRF_COOKIE_SAMESITE``    ``Lax``        ``Strict``
+============================================================= ============== ==========
+
+Documentation for these application variables is available in the
+`Dashboard configuration <am-dashboard-config_>`_.
+
+Storage Service application-specific environment variables
+==========================================================
+
+=========================== ============== ==========
+Variable Name               Previous Value New Value
+=========================== ============== ==========
+``SESSION_COOKIE_SECURE``   ``false``      ``true``
+``SESSION_COOKIE_HTTPONLY`` ``false``      ``true``
+``SESSION_COOKIE_SAMESITE`` ``Lax``        ``Strict``
+``CSRF_COOKIE_SECURE``      ``false``      ``true``
+``CSRF_COOKIE_HTTPONLY``    ``false``      ``true``
+``CSRF_COOKIE_SAMESITE``    ``Lax``        ``Strict``
+=========================== ============== ==========
+
+Documentation for these environment variables is available in the
+`Storage Service configuration <ss-config_>`_.
+
+.. note::
+
+   If your deployment uses OIDC authentication across different domains, you may
+   need to adjust these settings:
+
+   * Dashboard
+
+     + ``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SAMESITE``
+
+   * Storage Service
+
+     + ``SESSION_COOKIE_SAMESITE``
+
+   By default, they are set to ``Strict``, which may prevent cross-domain login
+   flows. In such cases, relax the settings to ``Lax`` to allow OIDC
+   authentication to function correctly across domains.
+
+.. note::
+
+   If your deployment does not use HTTPS (not recommended for production),
+   explicitly set these variables to ``false`` to allow cookies to be sent over
+   HTTP:
+
+   * Dashboard
+
+     + ``ARCHIVEMATICA_DASHBOARD_DASHBOARD_SESSION_COOKIE_SECURE``
+     + ``ARCHIVEMATICA_DASHBOARD_DASHBOARD_CSRF_COOKIE_SECURE``
+
+   * Storage Service
+
+     + ``SESSION_COOKIE_SECURE``
+     + ``CSRF_COOKIE_SECURE``
 
 When using HTTPS, it is still recommended to review `SSL/HTTPS <django-https-settings_>`_
 and related Django settings that provide additional security. You can continue
 to tune `session management <django-session-settings_>`_ if you need behaviour
 that differs from the defaults.
-
-If your deployment does not use HTTPS (not recommended for production),
-explicitly set the ``*_SESSION_COOKIE_SECURE`` and ``*_CSRF_COOKIE_SECURE``
-environment variables to ``false`` to allow cookies to be sent over HTTP.
 
 .. important::
 

--- a/admin-manual/security/security.rst
+++ b/admin-manual/security/security.rst
@@ -485,11 +485,11 @@ This will create a new :file:`/etc/ssl/certs/ca-certificates.crt` file.
 .. _requests: https://requests.readthedocs.io/en/master/
 .. _requests-cas: https://requests.readthedocs.io/en/master/user/advanced/#ca-certificates
 .. _elasticsearch-security-external: https://www.elastic.co/guide/en/x-pack/current/elasticsearch-security.html
-.. _ss-config: https://github.com/artefactual/archivematica-storage-service/blob/stable/0.23.x/install/README.md
+.. _ss-config: https://github.com/artefactual/archivematica-storage-service/blob/stable/0.24.x/install/README.md
 .. _mozilla-django-oidc-docs: https://mozilla-django-oidc.readthedocs.io/en/stable/
 .. _django-csp-docs: https://django-csp.readthedocs.io/en/latest/
 .. _django-https-settings: https://docs.djangoproject.com/en/3.2/topics/security/#ssl-https
 .. _django-session-settings: https://docs.djangoproject.com/en/3.2/topics/http/sessions/#settings
 .. _am-prod-settings: https://github.com/artefactual/archivematica/blob/stable/1.18.x/src/archivematica/dashboard/settings/production.py
-.. _ss-prod-settings: https://github.com/artefactual/archivematica-storage-service/blob/stable/0.23.x/storage_service/storage_service/settings/production.py
+.. _ss-prod-settings: https://github.com/artefactual/archivematica-storage-service/blob/stable/0.24.x/storage_service/storage_service/settings/production.py
 .. _cookie-configuration-improvements: https://wiki.archivematica.org/Archivematica_1.18.0_and_Storage_Service_0.24.0_release_notes#Cookie_configuration_improvements


### PR DESCRIPTION
This updates the cookie and session security section to include the
Dashboard application variables and the Storage Service
application-specific environment variables introduced in 1.18.0.

This is how the section looks now:
<img width="776" height="1519" alt="image" src="https://github.com/user-attachments/assets/f62c382c-023f-4eb3-a2f8-fa967b0574f4" />

